### PR TITLE
ヘッダーの追加

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "app",
       "version": "0.1.0",
       "dependencies": {
+        "@chakra-ui/icons": "^2.0.18",
         "@chakra-ui/react": "^2.5.5",
         "@emotion/react": "^11.10.6",
         "@emotion/styled": "^11.10.6",
@@ -455,6 +456,18 @@
       "integrity": "sha512-RpA1X5Ptz8Mt39HSyEIW1wxAz2AXyf9H0JJ5HVx/dBdMZaGMDJ0HyyPBVci0m4RCoJuyG1HHG/DXJaVfUTVAeg==",
       "dependencies": {
         "@chakra-ui/shared-utils": "2.0.5"
+      },
+      "peerDependencies": {
+        "@chakra-ui/system": ">=2.0.0",
+        "react": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/icons": {
+      "version": "2.0.18",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/icons/-/icons-2.0.18.tgz",
+      "integrity": "sha512-E/+DF/jw7kdN4/XxCZRnr4FdMXhkl50Q34MVwN9rADWMwPK9uSZPGyC7HOx6rilo7q4bFjYDH3yRj9g+VfbVkg==",
+      "dependencies": {
+        "@chakra-ui/icon": "3.0.16"
       },
       "peerDependencies": {
         "@chakra-ui/system": ">=2.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "firebase": "^9.19.1",
         "framer-motion": "^10.10.0",
         "next": "13.2.4",
+        "nookies": "^2.5.2",
         "react": "18.2.0",
         "react-dom": "18.2.0",
         "react-icons": "^4.8.0",
@@ -3104,6 +3105,14 @@
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
       "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A=="
     },
+    "node_modules/cookie": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
+      "integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/copy-to-clipboard": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/copy-to-clipboard/-/copy-to-clipboard-3.3.3.tgz",
@@ -5185,6 +5194,15 @@
         }
       }
     },
+    "node_modules/nookies": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/nookies/-/nookies-2.5.2.tgz",
+      "integrity": "sha512-x0TRSaosAEonNKyCrShoUaJ5rrT5KHRNZ5DwPCuizjgrnkpE5DRf3VL7AyyQin4htict92X1EQ7ejDbaHDVdYA==",
+      "dependencies": {
+        "cookie": "^0.4.1",
+        "set-cookie-parser": "^2.4.6"
+      }
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -5861,6 +5879,11 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.6.0.tgz",
+      "integrity": "sha512-RVnVQxTXuerk653XfuliOxBP81Sf0+qfQE73LIYKcyMYHG94AuH0kgrQpRDuTZnSmjpysHmzxJXKNfa6PjFhyQ=="
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "firebase": "^9.19.1",
     "framer-motion": "^10.10.0",
     "next": "13.2.4",
+    "nookies": "^2.5.2",
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-icons": "^4.8.0",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "format": "prettier --write --ignore-path .gitignore './**/*.{js,jsx,ts,tsx,json,css,scss}'"
   },
   "dependencies": {
+    "@chakra-ui/icons": "^2.0.18",
     "@chakra-ui/react": "^2.5.5",
     "@emotion/react": "^11.10.6",
     "@emotion/styled": "^11.10.6",

--- a/src/components/Layout/Header.tsx
+++ b/src/components/Layout/Header.tsx
@@ -1,0 +1,125 @@
+import { HamburgerIcon, CloseIcon } from '@chakra-ui/icons';
+import {
+  Box,
+  Flex,
+  Avatar,
+  HStack,
+  IconButton,
+  Button,
+  Menu,
+  MenuButton,
+  MenuList,
+  MenuItem,
+  MenuDivider,
+  useDisclosure,
+  useColorModeValue,
+  Stack,
+  Text,
+} from '@chakra-ui/react';
+import Link from 'next/link';
+import { BiLogOut } from 'react-icons/bi';
+
+const navbarLinks = [
+  { name: 'ホーム', url: '/' },
+  { name: 'ウツボ一覧', url: '/morays' },
+  { name: '水族館一覧', url: '/aquariums' },
+];
+
+export default function Header() {
+  const { isOpen, onOpen, onClose } = useDisclosure();
+  const name = 'Utsubo100';
+  const loading = false;
+  const currentUser = true;
+
+  return (
+    <Box bg={useColorModeValue('blue.500', 'blue.900')} px={4}>
+      <Flex alignItems={'center'} h={16} justifyContent={'space-between'}>
+        <IconButton
+          aria-label={'Open Menu'}
+          display={{ md: 'none' }}
+          icon={isOpen ? <CloseIcon /> : <HamburgerIcon />}
+          onClick={isOpen ? onClose : onOpen}
+          size={'md'}
+        />
+        <HStack alignItems={'center'} spacing={8}>
+          <Box>Logo</Box>
+          <HStack as={'nav'} display={{ base: 'none', md: 'flex' }} spacing={4}>
+            {navbarLinks.map((link) => (
+              <Link
+                _hover={{
+                  bg: 'gray.200',
+                  textDecoration: 'none',
+                }}
+                color={'whiteAlpha.900'}
+                href={link.url}
+                key={link.name} // key propsはイテレータ内でどのアイテムかをReactが認識するために使われる
+                px={2}
+                py={1}
+                rounded={'md'}
+              >
+                {link.name}
+              </Link>
+            ))}
+          </HStack>
+        </HStack>
+        <Flex alignItems={'center'}>
+          <Menu>
+            {!loading && currentUser ? (
+              <>
+                <MenuButton as={Button} cursor={'pointer'} minW={0} rounded={'full'} variant={'link'}>
+                  <Avatar
+                    size={'sm'}
+                    src={
+                      'https://images.unsplash.com/photo-1493666438817-866a91353ca9?ixlib=rb-0.3.5&q=80&fm=jpg&crop=faces&fit=crop&h=200&w=200&s=b616b2c5b373a80ffc9636ba24f7a4a9'
+                    }
+                  />
+                </MenuButton>
+                <MenuList>
+                  <MenuItem as="a" href="#">
+                    <Stack>
+                      <Text>ログインユーザー</Text>
+                      <Text as="b">{name}</Text>
+                    </Stack>
+                  </MenuItem>
+                  <MenuDivider />
+                  <MenuItem as="a" href="##">
+                    プロフィール編集
+                  </MenuItem>
+                  <MenuDivider />
+                  <MenuItem icon={<BiLogOut />} onClick={() => alert('logout!')}>
+                    ログアウト
+                  </MenuItem>
+                </MenuList>
+              </>
+            ) : (
+              <p>Login</p>
+            )}
+          </Menu>
+        </Flex>
+      </Flex>
+
+      {isOpen ? (
+        <Box display={{ md: 'none' }} pb={4}>
+          <Stack as={'nav'} spacing={4}>
+            {navbarLinks.map((link) => (
+              <Link
+                _hover={{
+                  bg: 'gray.200',
+                  textDecoration: 'none',
+                }}
+                color={'whiteAlpha.900'}
+                href={link.url}
+                key={link.name} // key propsはイテレータ内でどのアイテムかをReactが認識するために使われる
+                px={2}
+                py={1}
+                rounded={'md'}
+              >
+                {link.name}
+              </Link>
+            ))}
+          </Stack>
+        </Box>
+      ) : null}
+    </Box>
+  );
+}

--- a/src/components/Layout/Header.tsx
+++ b/src/components/Layout/Header.tsx
@@ -20,6 +20,8 @@ import {
 import NextLink from 'next/link';
 import { BiLogOut } from 'react-icons/bi';
 
+import { useAuthContext } from '@/context/AuthContext';
+
 const navbarLinks = [
   { name: 'ホーム', url: '/' },
   { name: 'ウツボ一覧', url: '/morays' },
@@ -28,9 +30,7 @@ const navbarLinks = [
 
 export default function Header() {
   const { isOpen, onOpen, onClose } = useDisclosure();
-  const name = 'Utsubo100';
-  const loading = false;
-  const currentUser = false;
+  const { currentUser, loading, logout, userInfo } = useAuthContext();
 
   return (
     <Box bg={useColorModeValue('blue.500', 'blue.900')} px={4}>
@@ -80,7 +80,7 @@ export default function Header() {
                   <MenuItem as="a" href="#">
                     <Stack>
                       <Text>ログインユーザー</Text>
-                      <Text as="b">{name}</Text>
+                      <Text as="b">{userInfo.name}</Text>
                     </Stack>
                   </MenuItem>
                   <MenuDivider />
@@ -88,7 +88,7 @@ export default function Header() {
                     プロフィール編集
                   </MenuItem>
                   <MenuDivider />
-                  <MenuItem icon={<BiLogOut />} onClick={() => alert('logout!')}>
+                  <MenuItem icon={<BiLogOut />} onClick={() => logout()}>
                     ログアウト
                   </MenuItem>
                 </MenuList>

--- a/src/components/Layout/Header.tsx
+++ b/src/components/Layout/Header.tsx
@@ -30,7 +30,7 @@ export default function Header() {
   const { isOpen, onOpen, onClose } = useDisclosure();
   const name = 'Utsubo100';
   const loading = false;
-  const currentUser = true;
+  const currentUser = false;
 
   return (
     <Box bg={useColorModeValue('blue.500', 'blue.900')} px={4}>
@@ -94,7 +94,9 @@ export default function Header() {
                 </MenuList>
               </>
             ) : (
-              <p>Login</p>
+              <Button as={NextLink} href="/signin">
+                ログイン
+              </Button>
             )}
           </Menu>
         </Flex>

--- a/src/components/Layout/Header.tsx
+++ b/src/components/Layout/Header.tsx
@@ -43,7 +43,9 @@ export default function Header() {
           size={'md'}
         />
         <HStack alignItems={'center'} spacing={8}>
-          <Box>Logo</Box>
+          <NextLink href="/">
+            <Box>Logo</Box>
+          </NextLink>
           <HStack as={'nav'} display={{ base: 'none', md: 'flex' }} spacing={4}>
             {navbarLinks.map((link) => (
               <Link

--- a/src/components/Layout/Header.tsx
+++ b/src/components/Layout/Header.tsx
@@ -15,8 +15,9 @@ import {
   useColorModeValue,
   Stack,
   Text,
+  Link,
 } from '@chakra-ui/react';
-import Link from 'next/link';
+import NextLink from 'next/link';
 import { BiLogOut } from 'react-icons/bi';
 
 const navbarLinks = [
@@ -50,6 +51,7 @@ export default function Header() {
                   bg: 'gray.200',
                   textDecoration: 'none',
                 }}
+                as={NextLink}
                 color={'whiteAlpha.900'}
                 href={link.url}
                 key={link.name} // key propsはイテレータ内でどのアイテムかをReactが認識するために使われる
@@ -107,6 +109,7 @@ export default function Header() {
                   bg: 'gray.200',
                   textDecoration: 'none',
                 }}
+                as={NextLink}
                 color={'whiteAlpha.900'}
                 href={link.url}
                 key={link.name} // key propsはイテレータ内でどのアイテムかをReactが認識するために使われる

--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -1,0 +1,10 @@
+import Header from './Header';
+
+export default function Layout({ children }) {
+  return (
+    <>
+      <Header />
+      <main>{children}</main>
+    </>
+  );
+}

--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -1,6 +1,12 @@
+import * as React from 'react';
+
 import Header from './Header';
 
-export default function Layout({ children }) {
+type Props = {
+  children: React.ReactNode;
+};
+
+export default function Layout({ children }: Props) {
   return (
     <>
       <Header />

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -1,0 +1,61 @@
+import { createContext, useContext, useState } from 'react';
+
+import { parseCookies } from 'nookies';
+
+import useFirebaseAuth from '@/hooks/useFirebaseAuth';
+
+import type { User } from 'firebase/auth';
+
+type UserInfo = {
+  avatar: string | null;
+  name: string;
+  uid: string;
+};
+
+type AuthContextType = {
+  currentUser: User | null;
+  loading: boolean;
+  loginWithGoogle: () => Promise<User | undefined>;
+  logout: () => Promise<void>;
+  updateUserInfo: (newUserInfo: UserInfo) => void;
+  userInfo: UserInfo;
+};
+
+type Props = {
+  children: React.ReactNode;
+};
+
+const AuthCtx = createContext<AuthContextType>({} as AuthContextType);
+
+const cookies = parseCookies();
+
+export function AuthContextProvider({ children }: Props) {
+  const { currentUser, loading, loginWithGoogle, logout } = useFirebaseAuth();
+  const [userInfo, setUserInfo] = useState({
+    avatar: cookies.avatar,
+    name: cookies.name,
+    uid: cookies.uid,
+  });
+
+  const updateUserInfo = (newUserInfo: UserInfo) => {
+    setUserInfo({
+      ...userInfo,
+      avatar: newUserInfo.avatar || '',
+      name: newUserInfo.name,
+      uid: newUserInfo.uid,
+    });
+  };
+
+  const AuthContext: AuthContextType = {
+    currentUser: currentUser,
+    loading: loading,
+    loginWithGoogle: loginWithGoogle,
+    logout: logout,
+    updateUserInfo: updateUserInfo,
+    userInfo: userInfo,
+  };
+
+  return <AuthCtx.Provider value={AuthContext}>{children}</AuthCtx.Provider>;
+}
+
+export const useAuthContext = () => useContext(AuthCtx);

--- a/src/hooks/useFirebaseAuth.ts
+++ b/src/hooks/useFirebaseAuth.ts
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react';
 
-import { onAuthStateChanged, signOut, signInWithPopup, GoogleAuthProvider } from 'firebase/auth';
+import { signOut, signInWithPopup, GoogleAuthProvider, onIdTokenChanged } from 'firebase/auth';
 import { useRouter } from 'next/router';
 
 import { auth } from '@/lib/initFirebase';
@@ -35,17 +35,31 @@ export default function useFirebaseAuth() {
   const nextOrObserver = async (user: User | null) => {
     if (!user) {
       setLoading(false);
+      setCurrentUser(null);
+      nookies.set(undefined, 'token', '', { path: '/' });
       return;
     }
 
     setLoading(true);
+    const token = await user.getIdToken();
     setCurrentUser(user);
+    nookies.set(undefined, 'token', token, { path: '/' });
     setLoading(false);
   };
 
   useEffect(() => {
-    const unsubscribe = onAuthStateChanged(auth, nextOrObserver);
+    const unsubscribe = onIdTokenChanged(auth, nextOrObserver);
     return unsubscribe;
+  }, []);
+
+  // 1時間毎にtokenを再取得する
+  useEffect(() => {
+    const handle = setInterval(async () => {
+      const user = auth.currentUser;
+      if (user) await user.getIdToken(true);
+    }, 60 * 60 * 1000);
+
+    return () => clearInterval(handle);
   }, []);
 
   return {

--- a/src/hooks/useFirebaseAuth.ts
+++ b/src/hooks/useFirebaseAuth.ts
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react';
 
 import { signOut, signInWithPopup, GoogleAuthProvider, onIdTokenChanged } from 'firebase/auth';
 import { useRouter } from 'next/router';
+import nookies from 'nookies';
 
 import { auth } from '@/lib/initFirebase';
 

--- a/src/lib/manageCookies.ts
+++ b/src/lib/manageCookies.ts
@@ -1,4 +1,4 @@
-import { nookies, setCookie, destroyCookie } from 'nookies';
+import nookies, { setCookie, destroyCookie } from 'nookies';
 
 type UserInfo = {
   avatar: string | null;

--- a/src/lib/manageCookies.ts
+++ b/src/lib/manageCookies.ts
@@ -1,0 +1,29 @@
+import { nookies, setCookie, destroyCookie } from 'nookies';
+
+type UserInfo = {
+  avatar: string | null;
+  name: string;
+  uid: string;
+};
+
+export const setUserInfoCookies = (userInfo: UserInfo) => {
+  setCookie(null, 'uid', userInfo.uid, {
+    maxAge: 30 * 24 * 60 * 60,
+    path: '/',
+  });
+  setCookie(null, 'name', userInfo.name, {
+    maxAge: 30 * 24 * 60 * 60,
+    path: '/',
+  });
+  setCookie(null, 'avatar', userInfo.avatar || '', {
+    maxAge: 30 * 24 * 60 * 60,
+    path: '/',
+  });
+};
+
+export const clearUserInfoCookies = () => {
+  nookies.destroy(null, 'token');
+  destroyCookie(null, 'uid');
+  destroyCookie(null, 'name');
+  destroyCookie(null, 'avatar');
+};

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,15 +1,18 @@
 import { ChakraProvider } from '@chakra-ui/react';
 
 import Layout from '@/components/Layout/Layout';
+import { AuthContextProvider } from '@/context/AuthContext';
 
 import type { AppProps } from 'next/app';
 
 export default function App({ Component, pageProps }: AppProps) {
   return (
     <ChakraProvider>
-      <Layout>
-        <Component {...pageProps} />
-      </Layout>
+      <AuthContextProvider>
+        <Layout>
+          <Component {...pageProps} />
+        </Layout>
+      </AuthContextProvider>
     </ChakraProvider>
   );
 }

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,11 +1,15 @@
 import { ChakraProvider } from '@chakra-ui/react';
 
+import Layout from '@/components/Layout/Layout';
+
 import type { AppProps } from 'next/app';
 
 export default function App({ Component, pageProps }: AppProps) {
   return (
     <ChakraProvider>
-      <Component {...pageProps} />
+      <Layout>
+        <Component {...pageProps} />
+      </Layout>
     </ChakraProvider>
   );
 }

--- a/src/pages/signin/index.tsx
+++ b/src/pages/signin/index.tsx
@@ -2,7 +2,7 @@ import { Box, Button, Center, Container, Divider, HStack, Heading, Stack, Text }
 import axios from 'axios';
 import { FcGoogle } from 'react-icons/fc';
 
-import useFirebaseAuth from '@/hooks/useFirebaseAuth';
+import { useAuthContext } from '@/context/AuthContext';
 import { setUserInfoCookies } from '@/lib/manageCookies';
 
 type UserInfo = {
@@ -12,7 +12,7 @@ type UserInfo = {
 };
 
 export default function SigninPage() {
-  const { loginWithGoogle, currentUser, logout } = useFirebaseAuth();
+  const { loginWithGoogle, updateUserInfo } = useAuthContext();
 
   const handleLogin = async () => {
     const user = await loginWithGoogle();
@@ -25,6 +25,7 @@ export default function SigninPage() {
     const res = await axios.post('http://localhost:3000/api/v1/auth', null, config);
     const userInfo: UserInfo = res.data;
     setUserInfoCookies(userInfo);
+    updateUserInfo(userInfo);
   };
 
   return (
@@ -57,12 +58,6 @@ export default function SigninPage() {
               <Text>Googleでログイン / ユーザー登録</Text>
             </Center>
           </Button>
-          <Button leftIcon={<FcGoogle />} maxW={'md'} onClick={() => logout()} variant={'outline'} w={'full'}>
-            <Center>
-              <Text>ログアウト</Text>
-            </Center>
-          </Button>
-          <p>ユーザー：{currentUser?.displayName}</p>
         </Stack>
       </Box>
     </Container>

--- a/src/pages/signin/index.tsx
+++ b/src/pages/signin/index.tsx
@@ -3,6 +3,13 @@ import axios from 'axios';
 import { FcGoogle } from 'react-icons/fc';
 
 import useFirebaseAuth from '@/hooks/useFirebaseAuth';
+import { setUserInfoCookies } from '@/lib/manageCookies';
+
+type UserInfo = {
+  avatar: string | null;
+  name: string;
+  uid: string;
+};
 
 export default function SigninPage() {
   const { loginWithGoogle, currentUser, logout } = useFirebaseAuth();
@@ -16,7 +23,8 @@ export default function SigninPage() {
     };
 
     const res = await axios.post('http://localhost:3000/api/v1/auth', null, config);
-    console.log(res);
+    const userInfo: UserInfo = res.data;
+    setUserInfoCookies(userInfo);
   };
 
   return (


### PR DESCRIPTION
## 対象Issue

[ヘッダーの作成 #11](https://github.com/Utsubo256/utsubo-site-client/issues/11)

## 実施内容

- ヘッダーの追加

## 動作確認

- ロゴがホーム画面 ('/')へのリンクとなっていることを確認
- ナビゲーションバーにウツボ一覧 (/morays)、水族館一覧 (/aquariums)へのリンクがあり、正しく遷移することを確認
- ログイン時にはプロフィールアイコン、ログアウト時にはログインボタンが表示されていることを確認
- ログイン時に表示されるプロフィールアイコンをクリックした際、各リンク「ユーザー名」「プロフィール編集」「ログアウト」が表示されることを確認
- ログアウトが動作することを確認
- 画面を小さくした際に、ハンバーガーメニューが表示されその中にアイコンや各リンクが表示されることを確認

close #11 