### PR TITLE
スタイルの修正

### DIFF
--- a/src/components/Layout/Footer.tsx
+++ b/src/components/Layout/Footer.tsx
@@ -4,7 +4,7 @@ import NextLink from 'next/link';
 export default function Footer() {
   return (
     <chakra.footer>
-      <Flex bg="blue.500" bottom={0} direction={'column'} pos="absolute" py={2} w="full">
+      <Flex bg="blue.500" bottom={0} direction={'column'} h="61px" pos="absolute" py={2} w="full">
         <Stack align="center" color="whiteAlpha.900" direction={'column'} spacing={0}>
           <Stack direction={'row'} spacing={2}>
             <Link as={NextLink} href={'/terms'}>

--- a/src/components/Layout/Footer.tsx
+++ b/src/components/Layout/Footer.tsx
@@ -5,7 +5,7 @@ export default function Footer() {
   return (
     <chakra.footer>
       <Flex bg="blue.500" bottom={0} direction={'column'} pos="absolute" py={2} w="full">
-        <Stack align="center" direction={'column'} spacing={0}>
+        <Stack align="center" color="whiteAlpha.900" direction={'column'} spacing={0}>
           <Stack direction={'row'} spacing={2}>
             <Link as={NextLink} href={'/terms'}>
               利用規約
@@ -21,7 +21,7 @@ export default function Footer() {
           </Stack>
           <Box mb={2}>
             <Spacer />
-            <Text fontSize="sm">Copyright &copy; {new Date().getFullYear()} - All right reserved by Utsubo</Text>
+            <Text fontSize="sm">Copyright &copy; {new Date().getFullYear()} - All right reserved by Utsubo256</Text>
             <Spacer />
           </Box>
         </Stack>

--- a/src/components/Layout/Header.tsx
+++ b/src/components/Layout/Header.tsx
@@ -12,7 +12,6 @@ import {
   MenuItem,
   MenuDivider,
   useDisclosure,
-  useColorModeValue,
   Stack,
   Text,
   Link,
@@ -34,95 +33,98 @@ export default function Header() {
   const { currentUser, loading, logout, userInfo } = useAuthContext();
 
   return (
-    <Box bg={useColorModeValue('blue.500', 'blue.900')} px={4}>
-      <Flex alignItems={'center'} h={16} justifyContent={'space-between'}>
-        <IconButton
-          aria-label={'Open Menu'}
-          display={{ md: 'none' }}
-          icon={isOpen ? <CloseIcon /> : <HamburgerIcon />}
-          onClick={isOpen ? onClose : onOpen}
-          size={'md'}
-        />
-        <HStack alignItems={'center'} spacing={8}>
-          <NextLink href="/">
-            <Image alt="utsubo-site-logo" h="40px" src="utsubo-site-logo.png" w="160px" />
-          </NextLink>
-          <HStack as={'nav'} display={{ base: 'none', md: 'flex' }} spacing={4}>
-            {navbarLinks.map((link) => (
-              <Link
-                _hover={{
-                  bg: 'gray.200',
-                  textDecoration: 'none',
-                }}
-                as={NextLink}
-                color={'whiteAlpha.900'}
-                href={link.url}
-                key={link.name} // key propsはイテレータ内でどのアイテムかをReactが認識するために使われる
-                px={2}
-                py={1}
-                rounded={'md'}
-              >
-                {link.name}
-              </Link>
-            ))}
+    <>
+      <Box bg="blue.500" h="64px" position="fixed" px={4} w={'full'} zIndex={100}>
+        <Flex alignItems={'center'} h={16} justifyContent={'space-between'}>
+          <IconButton
+            aria-label={'Open Menu'}
+            display={{ md: 'none' }}
+            icon={isOpen ? <CloseIcon /> : <HamburgerIcon />}
+            onClick={isOpen ? onClose : onOpen}
+            size={'md'}
+          />
+          <HStack alignItems={'center'} spacing={8}>
+            <NextLink href="/">
+              <Image alt="utsubo-site-logo" h="40px" src="utsubo-site-logo.png" w="160px" />
+            </NextLink>
+            <HStack as={'nav'} display={{ base: 'none', md: 'flex' }} spacing={4}>
+              {navbarLinks.map((link) => (
+                <Link
+                  _hover={{
+                    bg: 'gray.200',
+                    textDecoration: 'none',
+                  }}
+                  as={NextLink}
+                  color={'whiteAlpha.900'}
+                  href={link.url}
+                  key={link.name} // key propsはイテレータ内でどのアイテムかをReactが認識するために使われる
+                  px={2}
+                  py={1}
+                  rounded={'md'}
+                >
+                  {link.name}
+                </Link>
+              ))}
+            </HStack>
           </HStack>
-        </HStack>
-        <Flex alignItems={'center'}>
-          <Menu>
-            {!loading && currentUser ? (
-              <>
-                <MenuButton as={Button} cursor={'pointer'} minW={0} rounded={'full'} variant={'link'}>
-                  <Avatar size={'sm'} src="default-user-icon.png" />
-                </MenuButton>
-                <MenuList>
-                  <MenuItem as="a" href="#">
-                    <Stack>
-                      <Text>ログインユーザー</Text>
-                      <Text as="b">{userInfo.name}</Text>
-                    </Stack>
-                  </MenuItem>
-                  <MenuDivider />
-                  <MenuItem as="a" href="##">
-                    プロフィール編集
-                  </MenuItem>
-                  <MenuDivider />
-                  <MenuItem icon={<BiLogOut />} onClick={() => logout()}>
-                    ログアウト
-                  </MenuItem>
-                </MenuList>
-              </>
-            ) : (
-              <Button as={NextLink} href="/signin">
-                ログイン
-              </Button>
-            )}
-          </Menu>
+          <Flex alignItems={'center'}>
+            <Menu>
+              {!loading && currentUser ? (
+                <>
+                  <MenuButton as={Button} cursor={'pointer'} minW={0} rounded={'full'} variant={'link'}>
+                    <Avatar size={'sm'} src="default-user-icon.png" />
+                  </MenuButton>
+                  <MenuList>
+                    <MenuItem as="a" href="#">
+                      <Stack>
+                        <Text>ログインユーザー</Text>
+                        <Text as="b">{userInfo.name}</Text>
+                      </Stack>
+                    </MenuItem>
+                    <MenuDivider />
+                    <MenuItem as="a" href="##">
+                      プロフィール編集
+                    </MenuItem>
+                    <MenuDivider />
+                    <MenuItem icon={<BiLogOut />} onClick={() => logout()}>
+                      ログアウト
+                    </MenuItem>
+                  </MenuList>
+                </>
+              ) : (
+                <Button as={NextLink} href="/signin">
+                  ログイン
+                </Button>
+              )}
+            </Menu>
+          </Flex>
         </Flex>
-      </Flex>
 
-      {isOpen ? (
-        <Box display={{ md: 'none' }} pb={4}>
-          <Stack as={'nav'} spacing={4}>
-            {navbarLinks.map((link) => (
-              <Link
-                _hover={{
-                  bg: 'gray.200',
-                  textDecoration: 'none',
-                }}
-                as={NextLink}
-                color={'whiteAlpha.900'}
-                href={link.url}
-                key={link.name} // key propsはイテレータ内でどのアイテムかをReactが認識するために使われる
-                px={2}
-                py={1}
-                rounded={'md'}
-              >
-                {link.name}
-              </Link>
-            ))}
-          </Stack>
-        </Box>
-      ) : null}
-    </Box>
+        {isOpen ? (
+          <Box display={{ md: 'none' }} pb={4}>
+            <Stack as={'nav'} spacing={4}>
+              {navbarLinks.map((link) => (
+                <Link
+                  _hover={{
+                    bg: 'gray.200',
+                    textDecoration: 'none',
+                  }}
+                  as={NextLink}
+                  color={'whiteAlpha.900'}
+                  href={link.url}
+                  key={link.name} // key propsはイテレータ内でどのアイテムかをReactが認識するために使われる
+                  px={2}
+                  py={1}
+                  rounded={'md'}
+                >
+                  {link.name}
+                </Link>
+              ))}
+            </Stack>
+          </Box>
+        ) : null}
+      </Box>
+      <Box h="64px"></Box>
+    </>
   );
 }

--- a/src/components/Layout/Header.tsx
+++ b/src/components/Layout/Header.tsx
@@ -26,7 +26,7 @@ import { useAuthContext } from '@/context/AuthContext';
 const navbarLinks = [
   { name: 'ホーム', url: '/' },
   { name: 'ウツボ一覧', url: '/morays' },
-  { name: '水族館一覧', url: '/aquariums' },
+  { name: '水族館一覧', url: '/aquaria' },
 ];
 
 export default function Header() {

--- a/src/pages/aquaria/index.tsx
+++ b/src/pages/aquaria/index.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 
 import { Center, Image, LinkBox, LinkOverlay, Stack, Text, Wrap, WrapItem } from '@chakra-ui/react';
 import axios from 'axios';
+import Head from 'next/head';
 
 type Aquarium = {
   address_city: string;
@@ -42,6 +43,9 @@ export default function Aquaria() {
 
   return (
     <>
+      <Head>
+        <title>水族館一覧 - うつぼさいと</title>
+      </Head>
       <Center py="25px">
         <Text fontSize="3xl">水族館一覧</Text>
       </Center>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,4 +1,5 @@
 import { Box, Button, Center, Divider, SimpleGrid, Stack, Text, VStack } from '@chakra-ui/react';
+import Head from 'next/head';
 import { useRouter } from 'next/router';
 
 export default function LP() {
@@ -11,6 +12,9 @@ export default function LP() {
 
   return (
     <>
+      <Head>
+        <title>ホーム - うつぼさいと</title>
+      </Head>
       <Box
         alignItems="center"
         bgImage="url('hero-image.jpg')"

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -40,7 +40,7 @@ export default function LP() {
           </Text>
         </VStack>
       </Box>
-      <Box alignItems="center" display="flex" h="calc(100vh - 61px)" justifyContent="center">
+      <Box alignItems="center" display="flex" justifyContent="center" minH="calc(100vh - 61px)">
         <VStack>
           <Text fontSize={{ base: '3xl', lg: '3xl' }}>このサイトでできること</Text>
           <Divider borderColor="black" />

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -29,13 +29,13 @@ export default function LP() {
         <VStack>
           <Text
             color="whiteAlpha.900"
-            fontSize={{ lg: '6xl', md: '5xl', sm: '4xl' }}
+            fontSize={{ base: '2xl', lg: '6xl', md: '5xl', sm: '3xl' }}
             mt="50px"
             textShadow="1px 1px 5px gray"
           >
             ウツボを知って、観に行こう。
           </Text>
-          <Text color="whiteAlpha.900" fontSize={{ lg: '4xl', md: '3xl', sm: '2xl' }} textShadow="1px 1px 5px gray">
+          <Text color="whiteAlpha.900" fontSize={{ base: '2xl', lg: '4xl', md: '3xl' }} textShadow="1px 1px 5px gray">
             あなたもウツボがもっと好きになる
           </Text>
         </VStack>

--- a/src/pages/morays/index.tsx
+++ b/src/pages/morays/index.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 
 import { Center, Image, LinkBox, LinkOverlay, Stack, Text, Wrap, WrapItem } from '@chakra-ui/react';
 import axios from 'axios';
+import Head from 'next/head';
 
 type Moray = {
   avatar: string;
@@ -21,6 +22,9 @@ export default function Morays() {
 
   return (
     <>
+      <Head>
+        <title>ウツボ一覧 - うつぼさいと</title>
+      </Head>
       <Center py="25px">
         <Text fontSize="3xl">ウツボ一覧</Text>
       </Center>

--- a/src/pages/privacy/index.tsx
+++ b/src/pages/privacy/index.tsx
@@ -1,3 +1,12 @@
+import Head from 'next/head';
+
 export default function Privacy() {
-  return <div>プライバシーポリシー</div>;
+  return (
+    <>
+      <Head>
+        <title>プライバシーポリシー - うつぼさいと</title>
+      </Head>
+      <div>プライバシーポリシー</div>
+    </>
+  );
 }

--- a/src/pages/signin/index.tsx
+++ b/src/pages/signin/index.tsx
@@ -1,5 +1,6 @@
 import { Box, Button, Center, Container, Divider, HStack, Stack, Text } from '@chakra-ui/react';
 import axios from 'axios';
+import Head from 'next/head';
 import { FcGoogle } from 'react-icons/fc';
 
 import { useAuthContext } from '@/context/AuthContext';
@@ -30,6 +31,9 @@ export default function SigninPage() {
 
   return (
     <>
+      <Head>
+        <title>ログイン/ユーザー登録 - うつぼさいと</title>
+      </Head>
       <Center pt="25px">
         <Text fontSize="3xl">ログイン/ユーザー登録</Text>
       </Center>

--- a/src/pages/signin/index.tsx
+++ b/src/pages/signin/index.tsx
@@ -1,4 +1,4 @@
-import { Box, Button, Center, Container, Divider, HStack, Heading, Stack, Text } from '@chakra-ui/react';
+import { Box, Button, Center, Container, Divider, HStack, Stack, Text } from '@chakra-ui/react';
 import axios from 'axios';
 import { FcGoogle } from 'react-icons/fc';
 
@@ -29,37 +29,37 @@ export default function SigninPage() {
   };
 
   return (
-    <Container maxW="lg" px={{ base: '0', sm: '8' }} py={{ base: '12', md: '24' }}>
-      <Stack spacing="6">
-        <Stack spacing={{ base: '2', md: '3' }} textAlign="center">
-          <Heading size={{ base: 'xs', md: 'sm' }}>ログイン/ユーザー登録</Heading>
-        </Stack>
-      </Stack>
-      <Box
-        bg={{ base: 'transparent', sm: 'bg-surface' }}
-        borderRadius={{ base: 'none', sm: 'xl' }}
-        boxShadow={{ base: 'none', sm: 'md' }}
-        px={{ base: '4', sm: '10' }}
-        py={{ base: '0', sm: '8' }}
-      >
-        <Stack spacing="6">
-          <Button maxW={'md'} variant={'outline'} w={'full'}>
-            ゲストログイン
-          </Button>
-          <HStack>
-            <Divider />
-            <Text color="muted" fontSize="sm" whiteSpace="nowrap">
-              または
-            </Text>
-            <Divider />
-          </HStack>
-          <Button leftIcon={<FcGoogle />} maxW={'md'} onClick={() => handleLogin()} variant={'outline'} w={'full'}>
-            <Center>
-              <Text>Googleでログイン / ユーザー登録</Text>
-            </Center>
-          </Button>
-        </Stack>
-      </Box>
-    </Container>
+    <>
+      <Center pt="25px">
+        <Text fontSize="3xl">ログイン/ユーザー登録</Text>
+      </Center>
+      <Container maxW="lg" px={{ base: '0', sm: '8' }} py={12}>
+        <Box
+          bg="whiteAlpha.900"
+          borderRadius={{ base: 'none', sm: 'xl' }}
+          boxShadow={{ base: 'none', sm: 'md' }}
+          px={{ base: '4', sm: '10' }}
+          py={{ base: '0', sm: '8' }}
+        >
+          <Stack spacing="6">
+            <Button maxW={'md'} variant={'outline'} w={'full'}>
+              ゲストログイン
+            </Button>
+            <HStack>
+              <Divider />
+              <Text color="muted" fontSize="sm" whiteSpace="nowrap">
+                または
+              </Text>
+              <Divider />
+            </HStack>
+            <Button leftIcon={<FcGoogle />} maxW={'md'} onClick={() => handleLogin()} variant={'outline'} w={'full'}>
+              <Center>
+                <Text>Googleでログイン / ユーザー登録</Text>
+              </Center>
+            </Button>
+          </Stack>
+        </Box>
+      </Container>
+    </>
   );
 }

--- a/src/pages/terms/index.tsx
+++ b/src/pages/terms/index.tsx
@@ -1,3 +1,12 @@
+import Head from 'next/head';
+
 export default function Terms() {
-  return <div>利用規約</div>;
+  return (
+    <>
+      <Head>
+        <title>利用規約 - うつぼさいと</title>
+      </Head>
+      <div>利用規約</div>
+    </>
+  );
 }


### PR DESCRIPTION
## 対象Issue

[スタイルの修正 #16](https://github.com/Utsubo256/utsubo-site-client/issues/16)

## 実施内容

- Issueに記載したスタイルが崩れている箇所の修正

## 動作確認

- 画面スクロールをしてもヘッダーが上部に固定されていることを確認
- フッターのテキスト、色が修正できていることを確認
- 各ページにアクセスした際に、ブラウザのタブ名がHeadのtitleで指定した文字列になっていることを確認
- ログイン/ユーザー登録ページのh1タイトルが他のページタイトルと同じ大きさ・場所になっていることを確認
- ナビゲーションバー内の「水族館一覧」へのリンクがつながっていることを確認
- LPページが修正されていることを確認
- フッターについては[ウツボ一覧ページの作成 #17](https://github.com/Utsubo256/utsubo-site-client/pull/17)で修正済み

close #16 