### PR TITLE
ウツボ詳細/水族館詳細ページにコメント欄を追加

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@types/react": "18.0.33",
         "@types/react-dom": "18.0.11",
         "axios": "^1.3.5",
+        "date-fns": "^2.30.0",
         "eslint": "8.37.0",
         "eslint-config-next": "13.2.4",
         "firebase": "^9.19.1",
@@ -3177,6 +3178,21 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
       "integrity": "sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA=="
+    },
+    "node_modules/date-fns": {
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
+      "integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
+      "dependencies": {
+        "@babel/runtime": "^7.21.0"
+      },
+      "engines": {
+        "node": ">=0.11"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/date-fns"
+      }
     },
     "node_modules/debug": {
       "version": "4.3.4",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@types/react": "18.0.33",
     "@types/react-dom": "18.0.11",
     "axios": "^1.3.5",
+    "date-fns": "^2.30.0",
     "eslint": "8.37.0",
     "eslint-config-next": "13.2.4",
     "firebase": "^9.19.1",

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -8,7 +8,7 @@ import type { User } from 'firebase/auth';
 
 type UserInfo = {
   avatar: string | null;
-  id: string;
+  id: number;
   name: string;
 };
 

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -8,6 +8,7 @@ import type { User } from 'firebase/auth';
 
 type UserInfo = {
   avatar: string | null;
+  id: string;
   name: string;
 };
 
@@ -32,6 +33,7 @@ export function AuthContextProvider({ children }: Props) {
   const { currentUser, loading, loginWithFirebase, logout } = useFirebaseAuth();
   const [userInfo, setUserInfo] = useState({
     avatar: cookies.avatar,
+    id: cookies.id,
     name: cookies.name,
   });
 

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -33,7 +33,7 @@ export function AuthContextProvider({ children }: Props) {
   const { currentUser, loading, loginWithFirebase, logout } = useFirebaseAuth();
   const [userInfo, setUserInfo] = useState({
     avatar: cookies.avatar,
-    id: cookies.id,
+    id: Number(cookies.id),
     name: cookies.name,
   });
 

--- a/src/lib/manageCookies.ts
+++ b/src/lib/manageCookies.ts
@@ -2,10 +2,15 @@ import nookies, { setCookie, destroyCookie } from 'nookies';
 
 type UserInfo = {
   avatar: string | null;
+  id: string;
   name: string;
 };
 
 export const setUserInfoCookies = (userInfo: UserInfo) => {
+  setCookie(null, 'id', userInfo.id, {
+    maxAge: 30 * 24 * 60 * 60,
+    path: '/',
+  });
   setCookie(null, 'name', userInfo.name, {
     maxAge: 30 * 24 * 60 * 60,
     path: '/',

--- a/src/lib/manageCookies.ts
+++ b/src/lib/manageCookies.ts
@@ -7,7 +7,7 @@ type UserInfo = {
 };
 
 export const setUserInfoCookies = (userInfo: UserInfo) => {
-  setCookie(null, 'id', userInfo.id, {
+  setCookie(null, 'id', String(userInfo.id), {
     maxAge: 30 * 24 * 60 * 60,
     path: '/',
   });

--- a/src/lib/manageCookies.ts
+++ b/src/lib/manageCookies.ts
@@ -2,7 +2,7 @@ import nookies, { setCookie, destroyCookie } from 'nookies';
 
 type UserInfo = {
   avatar: string | null;
-  id: string;
+  id: number;
   name: string;
 };
 

--- a/src/pages/aquaria/[id].tsx
+++ b/src/pages/aquaria/[id].tsx
@@ -241,7 +241,7 @@ export default function AquariumDetail() {
           <VStack pb={4}>
             <Box display="flex" w={{ base: '80%', lg: '50%', md: '70%' }}>
               <HStack>
-                <Avatar size={'md'} src={userInfo.avatar ?? undefined} />
+                <Avatar size={'md'} src={userInfo.avatar ? userInfo.avatar : '/default-user-icon.png'} />
                 <Text fontSize="md">{userInfo.name}</Text>
               </HStack>
             </Box>

--- a/src/pages/aquaria/[id].tsx
+++ b/src/pages/aquaria/[id].tsx
@@ -95,7 +95,7 @@ export default function AquariumDetail() {
   const [aquariumCommentInput, setAquariumCommentInput] = useState<AquariumCommentInput>({
     body: '',
   });
-  const [aquariumComments, setAquariumComments] = useState<AquariumComments>([]);
+  const [aquariumComments, setAquariumComments] = useState<AquariumComments[]>([]);
 
   function onSubmit(e: React.SyntheticEvent) {
     e.preventDefault();

--- a/src/pages/aquaria/[id].tsx
+++ b/src/pages/aquaria/[id].tsx
@@ -1,10 +1,39 @@
 import { useEffect, useState } from 'react';
 
-import { Box, Center, Image, Link, LinkBox, LinkOverlay, Stack, Text, VStack, Wrap, WrapItem } from '@chakra-ui/react';
+import {
+  Avatar,
+  Box,
+  Button,
+  Center,
+  Divider,
+  HStack,
+  Icon,
+  Image,
+  Link,
+  LinkBox,
+  LinkOverlay,
+  Menu,
+  MenuButton,
+  MenuItem,
+  MenuList,
+  Stack,
+  Text,
+  Textarea,
+  VStack,
+  Wrap,
+  WrapItem,
+} from '@chakra-ui/react';
 import axios from 'axios';
+import { parseISO } from 'date-fns';
+import formatDistanceToNow from 'date-fns/formatDistanceToNow';
+import ja from 'date-fns/locale/ja';
 import Head from 'next/head';
 import NextLink from 'next/link';
 import { useRouter } from 'next/router';
+import nookies from 'nookies';
+import { BsThreeDots } from 'react-icons/bs';
+
+import { useAuthContext } from '@/context/AuthContext';
 
 type Moray = {
   avatar: string;
@@ -28,9 +57,27 @@ type Aquarium = {
   site_url: string;
 };
 
+type AquariumComments = {
+  body: string;
+  created_at: string;
+  id: number;
+  image: string | null;
+  user: {
+    avatar: string | null;
+    id: number;
+    name: string;
+  };
+};
+
+type AquariumCommentInput = {
+  body: string;
+};
+
 export default function AquariumDetail() {
   const router = useRouter();
   const { id } = router.query;
+
+  const { currentUser, loading, userInfo } = useAuthContext();
 
   const [aquariumDetail, setAquariumDetail] = useState<Aquarium>({
     address_detail: '',
@@ -45,11 +92,65 @@ export default function AquariumDetail() {
     site_url: '',
   });
 
+  const [aquariumCommentInput, setAquariumCommentInput] = useState<AquariumCommentInput>({
+    body: '',
+  });
+  const [aquariumComments, setAquariumComments] = useState<AquariumComments>([]);
+
+  function onSubmit(e: React.SyntheticEvent) {
+    e.preventDefault();
+    const data = {
+      aquarium_comment: {
+        body: aquariumCommentInput.body,
+      },
+    };
+    const cookies = nookies.get();
+    const config = {
+      headers: { authorization: `Bearer ${cookies.token}` },
+    };
+
+    if (router.isReady) {
+      axios
+        .post(`${process.env.NEXT_PUBLIC_BASE_URL}/aquaria/${id}/aquarium_comments`, data, config)
+        .then(() => {
+          axios
+            .get(`${process.env.NEXT_PUBLIC_BASE_URL}/aquaria/${id}/aquarium_comments`)
+            .then((res) => setAquariumComments(res.data));
+        })
+        .catch((e) => console.log(e));
+    }
+    setAquariumCommentInput({ body: '' });
+  }
+
+  function onDelete(comment_id: number) {
+    if (router.isReady) {
+      const cookies = nookies.get();
+      const config = {
+        headers: { authorization: `Bearer ${cookies.token}` },
+      };
+
+      axios
+        .delete(`${process.env.NEXT_PUBLIC_BASE_URL}/aquaria/${id}/aquarium_comments/${comment_id}`, config)
+        .then(() => {
+          axios
+            .get(`${process.env.NEXT_PUBLIC_BASE_URL}/aquaria/${id}/aquarium_comments`)
+            .then((res) => setAquariumComments(res.data));
+        });
+    }
+  }
+
   useEffect(() => {
     if (router.isReady) {
       axios.get(`${process.env.NEXT_PUBLIC_BASE_URL}/aquaria/${id}`).then((res) => setAquariumDetail(res.data));
+      axios
+        .get(`${process.env.NEXT_PUBLIC_BASE_URL}/aquaria/${id}/aquarium_comments`)
+        .then((res) => setAquariumComments(res.data));
     }
   }, [id, router]);
+
+  function elapsedTimeFromNow(datetime: string) {
+    return formatDistanceToNow(parseISO(datetime), { locale: ja });
+  }
 
   return (
     <>
@@ -132,6 +233,119 @@ export default function AquariumDetail() {
           </WrapItem>
         ))}
       </Wrap>
+      <VStack py="25px">
+        <Text fontSize="2xl">コメント</Text>
+      </VStack>
+      {!loading && currentUser ? (
+        <>
+          <VStack pb={4}>
+            <Box display="flex" w={{ base: '80%', lg: '50%', md: '70%' }}>
+              <HStack>
+                <Avatar size={'md'} src={userInfo.avatar ?? undefined} />
+                <Text fontSize="md">{userInfo.name}</Text>
+              </HStack>
+            </Box>
+          </VStack>
+          <VStack>
+            <Box w={{ base: '80%', lg: '50%', md: '70%' }}>
+              <form onSubmit={onSubmit}>
+                <Textarea
+                  bg="white"
+                  onChange={(e) => setAquariumCommentInput({ ...aquariumCommentInput, body: e.target.value })}
+                  placeholder="コメントを入力"
+                  value={aquariumCommentInput.body}
+                  variant="outline"
+                />
+                <Box display="flex" justifyContent="flex-end" py={2}>
+                  <Button
+                    _hover={{ bg: 'blue.300' }}
+                    bg="blue.500"
+                    color="whiteAlpha.900"
+                    isDisabled={aquariumCommentInput.body === '' || aquariumCommentInput.body?.length > 255}
+                    type="submit"
+                  >
+                    投稿する
+                  </Button>
+                </Box>
+                <Divider borderColor="gray.400" />
+              </form>
+            </Box>
+          </VStack>
+        </>
+      ) : (
+        <VStack>
+          <Box
+            alignItems="center"
+            bg="whiteAlpha.800"
+            borderRadius="30px"
+            display="flex"
+            h="200px"
+            justifyContent="center"
+            rounded="lg"
+            shadow="lg"
+            w={{ base: '80%', lg: '50%', md: '70%' }}
+          >
+            <VStack>
+              <Text fontSize="lg" fontWeight="bold">
+                ログインしてコメントを投稿しよう！
+              </Text>
+              <Text fontSize="sm" w={{ lg: '100%', md: '100%', sm: '75%' }}>
+                ゲストログインするとアカウント登録なしでコメント投稿ができます
+              </Text>
+              <Box h={4}></Box>
+              <Button _hover={{ bg: 'blue.300' }} as={NextLink} bg="blue.500" color="whiteAlpha.900" href="/signin">
+                ログインする
+              </Button>
+            </VStack>
+          </Box>
+        </VStack>
+      )}
+      {aquariumComments.length ? (
+        <VStack pb={8}>
+          <Box w={{ base: '80%', lg: '50%', md: '70%' }}>
+            {aquariumComments.map((aquariumComment) => (
+              <>
+                <Box py={4}>
+                  <Box display="flex" justifyContent="space-between">
+                    <HStack spacing={2}>
+                      {aquariumComment.user.avatar ? (
+                        <Avatar size={'md'} src={aquariumComment.user.avatar ?? undefined} />
+                      ) : (
+                        <Avatar size={'md'} src="/default-user-icon.png" />
+                      )}
+                      <Text fontSize="md">{aquariumComment.user.name}</Text>
+                      <Text fontSize="xs">{elapsedTimeFromNow(aquariumComment.created_at)}</Text>
+                    </HStack>
+                    <Menu>
+                      {aquariumComment.user.id === Number(userInfo.id) ? (
+                        <Box>
+                          <MenuButton>
+                            <Icon as={BsThreeDots} boxSize="20px" />
+                          </MenuButton>
+                          <MenuList>
+                            {/* <MenuItem onClick={() => alert('updated!')}>編集する</MenuItem> */}
+                            <MenuItem onClick={() => onDelete(aquariumComment.id)}>削除する</MenuItem>
+                          </MenuList>
+                        </Box>
+                      ) : null}
+                    </Menu>
+                  </Box>
+                </Box>
+                <Text fontSize="md" whiteSpace={'pre-wrap'}>
+                  {aquariumComment.body}
+                </Text>
+                <Divider borderColor="gray.400" pt={4} />
+              </>
+            ))}
+          </Box>
+        </VStack>
+      ) : (
+        <Center>
+          <Text fontSize="xl" py={12}>
+            まだコメントはありません。
+          </Text>
+        </Center>
+      )}
     </>
   );
 }

--- a/src/pages/morays/[id].tsx
+++ b/src/pages/morays/[id].tsx
@@ -216,7 +216,7 @@ export default function MorayDetail() {
           <VStack pb={4}>
             <Box display="flex" w={{ base: '80%', lg: '50%', md: '70%' }}>
               <HStack>
-                <Avatar size={'md'} src={userInfo.avatar} />
+                <Avatar size={'md'} src={userInfo.avatar ?? undefined} />
                 <Text fontSize="md">{userInfo.name}</Text>
               </HStack>
             </Box>
@@ -284,7 +284,7 @@ export default function MorayDetail() {
                   <Box display="flex" justifyContent="space-between">
                     <HStack spacing={2}>
                       {morayComment.user.avatar ? (
-                        <Avatar size={'md'} src={morayComment.user.avatar} />
+                        <Avatar size={'md'} src={morayComment.user.avatar ?? undefined} />
                       ) : (
                         <Avatar size={'md'} src="/default-user-icon.png" />
                       )}

--- a/src/pages/morays/[id].tsx
+++ b/src/pages/morays/[id].tsx
@@ -23,7 +23,7 @@ import {
   Icon,
 } from '@chakra-ui/react';
 import axios from 'axios';
-import { format, parseISO } from 'date-fns';
+import { parseISO } from 'date-fns';
 import formatDistanceToNow from 'date-fns/formatDistanceToNow';
 import ja from 'date-fns/locale/ja';
 import Head from 'next/head';
@@ -144,11 +144,6 @@ export default function MorayDetail() {
         .then((res) => setMorayComments(res.data));
     }
   }, [id, router]);
-
-  function formatDatetime(datetime: string) {
-    const formattedDatetime = format(parseISO(datetime), 'yyyy年MM月dd日 hh:mm', { locale: ja });
-    return formattedDatetime;
-  }
 
   function elapsedTimeFromNow(datetime: string) {
     return formatDistanceToNow(parseISO(datetime), { locale: ja });

--- a/src/pages/morays/[id].tsx
+++ b/src/pages/morays/[id].tsx
@@ -216,7 +216,7 @@ export default function MorayDetail() {
           <VStack pb={4}>
             <Box display="flex" w={{ base: '80%', lg: '50%', md: '70%' }}>
               <HStack>
-                <Avatar size={'md'} src={userInfo.avatar ?? undefined} />
+                <Avatar size={'md'} src={userInfo.avatar ? userInfo.avatar : '/default-user-icon.png'} />
                 <Text fontSize="md">{userInfo.name}</Text>
               </HStack>
             </Box>

--- a/src/pages/morays/[id].tsx
+++ b/src/pages/morays/[id].tsx
@@ -292,7 +292,7 @@ export default function MorayDetail() {
                       <Text fontSize="xs">{elapsedTimeFromNow(morayComment.created_at)}</Text>
                     </HStack>
                     <Menu>
-                      {morayComment.user.id === parseInt(userInfo.id, 10) ? (
+                      {morayComment.user.id === Number(userInfo.id) ? (
                         <Box>
                           <MenuButton>
                             <Icon as={BsThreeDots} boxSize="20px" />

--- a/src/pages/morays/[id].tsx
+++ b/src/pages/morays/[id].tsx
@@ -1,10 +1,38 @@
 import { useEffect, useState } from 'react';
 
-import { Box, Center, Image, LinkBox, LinkOverlay, Stack, Text, VStack, Wrap, WrapItem } from '@chakra-ui/react';
+import {
+  Avatar,
+  Box,
+  Button,
+  Center,
+  Divider,
+  HStack,
+  Image,
+  LinkBox,
+  LinkOverlay,
+  Menu,
+  MenuButton,
+  MenuItem,
+  MenuList,
+  Stack,
+  Text,
+  Textarea,
+  VStack,
+  Wrap,
+  WrapItem,
+  Icon,
+} from '@chakra-ui/react';
 import axios from 'axios';
+import { format, parseISO } from 'date-fns';
+import formatDistanceToNow from 'date-fns/formatDistanceToNow';
+import ja from 'date-fns/locale/ja';
 import Head from 'next/head';
 import NextLink from 'next/link';
 import { useRouter } from 'next/router';
+import nookies from 'nookies';
+import { BsThreeDots } from 'react-icons/bs';
+
+import { useAuthContext } from '@/context/AuthContext';
 
 type Aquarium = {
   address_city: string;
@@ -27,9 +55,27 @@ type Moray = {
   video_url: string;
 };
 
+type MorayComments = {
+  body: string;
+  created_at: string;
+  id: number;
+  image: string | null;
+  user: {
+    avatar: string | null;
+    id: number;
+    name: string;
+  };
+};
+
+type MorayCommentInput = {
+  body: string;
+};
+
 export default function MorayDetail() {
   const router = useRouter();
   const { id } = router.query;
+
+  const { currentUser, loading, userInfo } = useAuthContext();
 
   const [morayDetail, setMorayDetail] = useState<Moray>({
     aquaria: [],
@@ -44,11 +90,69 @@ export default function MorayDetail() {
     video_url: '',
   });
 
+  const [morayCommentInput, setMorayCommentInput] = useState<MorayCommentInput>({
+    body: '',
+  });
+  const [morayComments, setMorayComments] = useState<MorayComments[]>([]);
+
+  function onSubmit(e: React.SyntheticEvent) {
+    e.preventDefault();
+    const data = {
+      moray_comment: {
+        body: morayCommentInput.body,
+      },
+    };
+
+    const cookies = nookies.get();
+    const config = {
+      headers: { authorization: `Bearer ${cookies.token}` },
+    };
+
+    if (router.isReady) {
+      axios
+        .post(`${process.env.NEXT_PUBLIC_BASE_URL}/morays/${id}/moray_comments`, data, config)
+        .then(() => {
+          axios
+            .get(`${process.env.NEXT_PUBLIC_BASE_URL}/morays/${id}/moray_comments`)
+            .then((res) => setMorayComments(res.data));
+        })
+        .catch((e) => console.log(e));
+    }
+    setMorayCommentInput({ body: '' });
+  }
+
+  function onDelete(comment_id: number) {
+    if (router.isReady) {
+      const cookies = nookies.get();
+      const config = {
+        headers: { authorization: `Bearer ${cookies.token}` },
+      };
+
+      axios.delete(`${process.env.NEXT_PUBLIC_BASE_URL}/morays/${id}/moray_comments/${comment_id}`, config).then(() => {
+        axios
+          .get(`${process.env.NEXT_PUBLIC_BASE_URL}/morays/${id}/moray_comments`)
+          .then((res) => setMorayComments(res.data));
+      });
+    }
+  }
+
   useEffect(() => {
     if (router.isReady) {
       axios.get(`${process.env.NEXT_PUBLIC_BASE_URL}/morays/${id}`).then((res) => setMorayDetail(res.data));
+      axios
+        .get(`${process.env.NEXT_PUBLIC_BASE_URL}/morays/${id}/moray_comments`)
+        .then((res) => setMorayComments(res.data));
     }
   }, [id, router]);
+
+  function formatDatetime(datetime: string) {
+    const formattedDatetime = format(parseISO(datetime), 'yyyy年MM月dd日 hh:mm', { locale: ja });
+    return formattedDatetime;
+  }
+
+  function elapsedTimeFromNow(datetime: string) {
+    return formatDistanceToNow(parseISO(datetime), { locale: ja });
+  }
 
   return (
     <>
@@ -58,7 +162,6 @@ export default function MorayDetail() {
       <Center py="25px">
         <Text fontSize="3xl">{morayDetail.name_ja}</Text>
       </Center>
-
       <VStack>
         <Image alt="moray_image" borderRadius="full" boxSize="200px" src={`/moray_image/${morayDetail.avatar}`} />
         <Box pt="25px">
@@ -67,18 +170,17 @@ export default function MorayDetail() {
           {/* <Text fontSize={'xl'}>分布: {morayDetail.distribution}</Text> */}
           <Text fontSize={'xl'}>{`最大長: ${morayDetail.max_length_str ?? '???cm'}`}</Text>
         </Box>
-        <VStack pt="20px" w={{ lg: '35%', md: '45%', sm: '70%' }}>
+        <VStack pt="20px" w={{ base: '70%', lg: '35%', md: '45%' }}>
           <Text fontSize={'2xl'}>ひとことメモ</Text>
           <Text fontSize={'xl'}>{morayDetail.description ?? '調査中です！しばらくお待ちください。'}</Text>
         </VStack>
       </VStack>
-
       <VStack py="25px" spacing={0}>
-        <Text fontSize="3xl">このウツボが観られる水族館</Text>
-        <Text color="red.500" fontSize="md">
+        <Text fontSize="2xl">このウツボが観られる水族館</Text>
+        <Text color="red.500" fontSize="sm">
           ※ご注意※
         </Text>
-        <Text color="red.500" fontSize="md">
+        <Text color="red.500" fontSize="sm">
           展示されるウツボは通知無く変更される場合があります。
         </Text>
       </VStack>
@@ -111,6 +213,119 @@ export default function MorayDetail() {
           </WrapItem>
         ))}
       </Wrap>
+      <VStack py="25px">
+        <Text fontSize="2xl">コメント</Text>
+      </VStack>
+      {!loading && currentUser ? (
+        <>
+          <VStack pb={4}>
+            <Box display="flex" w={{ base: '80%', lg: '50%', md: '70%' }}>
+              <HStack>
+                <Avatar size={'md'} src={userInfo.avatar} />
+                <Text fontSize="md">{userInfo.name}</Text>
+              </HStack>
+            </Box>
+          </VStack>
+          <VStack>
+            <Box w={{ base: '80%', lg: '50%', md: '70%' }}>
+              <form onSubmit={onSubmit}>
+                <Textarea
+                  bg="white"
+                  onChange={(e) => setMorayCommentInput({ ...morayCommentInput, body: e.target.value })}
+                  placeholder="コメントを入力"
+                  value={morayCommentInput.body}
+                  variant="outline"
+                />
+                <Box display="flex" justifyContent="flex-end" py={2}>
+                  <Button
+                    _hover={{ bg: 'blue.300' }}
+                    bg="blue.500"
+                    color="whiteAlpha.900"
+                    isDisabled={morayCommentInput.body === '' || morayCommentInput.body?.length > 255}
+                    type="submit"
+                  >
+                    投稿する
+                  </Button>
+                </Box>
+                <Divider borderColor="gray.400" />
+              </form>
+            </Box>
+          </VStack>
+        </>
+      ) : (
+        <VStack>
+          <Box
+            alignItems="center"
+            bg="whiteAlpha.800"
+            borderRadius="30px"
+            display="flex"
+            h="200px"
+            justifyContent="center"
+            rounded="lg"
+            shadow="lg"
+            w={{ base: '80%', lg: '50%', md: '70%' }}
+          >
+            <VStack>
+              <Text fontSize="lg" fontWeight="bold">
+                ログインしてコメントを投稿しよう！
+              </Text>
+              <Text fontSize="sm" w={{ lg: '100%', md: '100%', sm: '75%' }}>
+                ゲストログインするとアカウント登録なしでコメント投稿ができます
+              </Text>
+              <Box h={4}></Box>
+              <Button _hover={{ bg: 'blue.300' }} as={NextLink} bg="blue.500" color="whiteAlpha.900" href="/signin">
+                ログインする
+              </Button>
+            </VStack>
+          </Box>
+        </VStack>
+      )}
+      {morayComments.length ? (
+        <VStack pb={8}>
+          <Box w={{ base: '80%', lg: '50%', md: '70%' }}>
+            {morayComments.map((morayComment) => (
+              <>
+                <Box py={4}>
+                  <Box display="flex" justifyContent="space-between">
+                    <HStack spacing={2}>
+                      {morayComment.user.avatar ? (
+                        <Avatar size={'md'} src={morayComment.user.avatar} />
+                      ) : (
+                        <Avatar size={'md'} src="/default-user-icon.png" />
+                      )}
+                      <Text fontSize="md">{morayComment.user.name}</Text>
+                      <Text fontSize="xs">{elapsedTimeFromNow(morayComment.created_at)}</Text>
+                    </HStack>
+                    <Menu>
+                      {morayComment.user.id == userInfo.id ? (
+                        <Box>
+                          <MenuButton>
+                            <Icon as={BsThreeDots} boxSize="20px" />
+                          </MenuButton>
+                          <MenuList>
+                            {/* <MenuItem onClick={() => alert('updated!')}>編集する</MenuItem> */}
+                            <MenuItem onClick={() => onDelete(morayComment.id)}>削除する</MenuItem>
+                          </MenuList>
+                        </Box>
+                      ) : null}
+                    </Menu>
+                  </Box>
+                </Box>
+                <Text fontSize="md" whiteSpace={'pre-wrap'}>
+                  {morayComment.body}
+                </Text>
+                <Divider borderColor="gray.400" pt={4} />
+              </>
+            ))}
+          </Box>
+        </VStack>
+      ) : (
+        <Center>
+          <Text fontSize="xl" py={12}>
+            まだコメントはありません。
+          </Text>
+        </Center>
+      )}
     </>
   );
 }

--- a/src/pages/morays/[id].tsx
+++ b/src/pages/morays/[id].tsx
@@ -292,7 +292,7 @@ export default function MorayDetail() {
                       <Text fontSize="xs">{elapsedTimeFromNow(morayComment.created_at)}</Text>
                     </HStack>
                     <Menu>
-                      {morayComment.user.id == userInfo.id ? (
+                      {morayComment.user.id === parseInt(userInfo.id, 10) ? (
                         <Box>
                           <MenuButton>
                             <Icon as={BsThreeDots} boxSize="20px" />

--- a/src/pages/signin/index.tsx
+++ b/src/pages/signin/index.tsx
@@ -9,8 +9,8 @@ import { setUserInfoCookies } from '@/lib/manageCookies';
 
 type UserInfo = {
   avatar: string | null;
+  id: number;
   name: string;
-  uid: string;
 };
 
 export default function SigninPage() {


### PR DESCRIPTION
## 対象Issue

[ウツボ詳細/水族館詳細ページにコメント欄を追加 #44](https://github.com/Utsubo256/utsubo-site-client/issues/44)

## 実施内容

- ウツボ詳細ページにコメント機能 (一覧表示、投稿、削除)を追加
- 水族館詳細ページにコメント機能 (一覧表示、投稿、削除)を追加

## 動作確認

- Issueに書かれていることが実装できていることを確認

close #44 