### PR TITLE
スタイルの修正

### DIFF
--- a/src/components/Layout/Header.tsx
+++ b/src/components/Layout/Header.tsx
@@ -18,6 +18,7 @@ import {
   Image,
 } from '@chakra-ui/react';
 import NextLink from 'next/link';
+import { useRouter } from 'next/router';
 import { BiLogOut } from 'react-icons/bi';
 
 import { useAuthContext } from '@/context/AuthContext';
@@ -29,8 +30,14 @@ const navbarLinks = [
 ];
 
 export default function Header() {
+  const router = useRouter();
   const { isOpen, onOpen, onClose } = useDisclosure();
   const { currentUser, loading, logout, userInfo } = useAuthContext();
+
+  function handleLink(link: string) {
+    router.push(link);
+    onClose();
+  }
 
   return (
     <>
@@ -104,21 +111,21 @@ export default function Header() {
           <Box display={{ md: 'none' }} pb={4}>
             <Stack as={'nav'} spacing={4}>
               {navbarLinks.map((link) => (
-                <Link
+                <Button
                   _hover={{
                     bg: 'blue.300',
                     textDecoration: 'none',
                   }}
-                  as={NextLink}
+                  bg="blue.500"
                   color={'whiteAlpha.900'}
-                  href={link.url}
                   key={link.name} // key propsはイテレータ内でどのアイテムかをReactが認識するために使われる
+                  onClick={() => handleLink(link.url)}
                   px={2}
                   py={1}
                   rounded={'md'}
                 >
                   {link.name}
-                </Link>
+                </Button>
               ))}
             </Stack>
           </Box>

--- a/src/pages/aquaria/[id].tsx
+++ b/src/pages/aquaria/[id].tsx
@@ -6,6 +6,8 @@ import {
   Button,
   Center,
   Divider,
+  Grid,
+  GridItem,
   HStack,
   Icon,
   Image,
@@ -20,8 +22,6 @@ import {
   Text,
   Textarea,
   VStack,
-  Wrap,
-  WrapItem,
 } from '@chakra-ui/react';
 import axios from 'axios';
 import { parseISO } from 'date-fns';
@@ -160,79 +160,85 @@ export default function AquariumDetail() {
       <Center py="25px">
         <Text fontSize="3xl">{aquariumDetail.name}</Text>
       </Center>
-      <VStack>
-        <Image
-          alt={aquariumDetail.name}
-          boxSize="200px"
-          rounded={'lg'}
-          src={`/aquarium_image/${aquariumDetail.image}`}
-          w="300px"
-        />
-        <Box>
-          <Text fontSize={'xl'}>
-            サイト　:{' '}
-            <Link as={NextLink} color="blue.400" href={aquariumDetail.site_url} isExternal>
-              {aquariumDetail.site_url}
-            </Link>
-          </Text>
-          <Text fontSize={'xl'}>
-            営業日時:{' '}
-            <Link as={NextLink} color="blue.400" href={aquariumDetail.business_days_hours_url} isExternal>
-              {aquariumDetail.business_days_hours_url}
-            </Link>
-          </Text>
-          <Text fontSize={'xl'}>
-            料金　　:{' '}
-            <Link as={NextLink} color="blue.400" href={aquariumDetail.entrance_fee_url} isExternal>
-              {aquariumDetail.entrance_fee_url}
-            </Link>
-          </Text>
-          <Text fontSize={'xl'}>住所　　: {aquariumDetail.address_detail}</Text>
+      <Center>
+        <Box w={{ base: '85%', lg: '100%', md: '85%' }}>
+          <VStack>
+            <Image
+              alt={aquariumDetail.name}
+              boxSize="200px"
+              rounded={'lg'}
+              src={`/aquarium_image/${aquariumDetail.image}`}
+              w="300px"
+            />
+            <Box>
+              <Text fontSize={'xl'}>
+                サイト　:{' '}
+                <Link as={NextLink} color="blue.400" href={aquariumDetail.site_url} isExternal>
+                  {aquariumDetail.site_url}
+                </Link>
+              </Text>
+              <Text fontSize={'xl'}>
+                営業日時:{' '}
+                <Link as={NextLink} color="blue.400" href={aquariumDetail.business_days_hours_url} isExternal>
+                  {aquariumDetail.business_days_hours_url}
+                </Link>
+              </Text>
+              <Text fontSize={'xl'}>
+                料金　　:{' '}
+                <Link as={NextLink} color="blue.400" href={aquariumDetail.entrance_fee_url} isExternal>
+                  {aquariumDetail.entrance_fee_url}
+                </Link>
+              </Text>
+              <Text fontSize={'xl'}>住所　　: {aquariumDetail.address_detail}</Text>
+            </Box>
+            <VStack pt="20px" w={{ lg: '35%', md: '45%', sm: '70%' }}>
+              <Text fontSize={'2xl'}>ひとことメモ</Text>
+              <Text fontSize={'xl'}>{aquariumDetail.description ?? '調査中です！しばらくお待ちください。'}</Text>
+            </VStack>
+          </VStack>
+          <VStack py="25px" spacing={0}>
+            <Text fontSize="2xl">この水族館で観られるウツボ</Text>
+            <Text color="red.500" fontSize="sm">
+              ※ご注意※
+            </Text>
+            <Text color="red.500" fontSize="sm">
+              展示されるウツボは通知無く変更される場合があります。
+            </Text>
+          </VStack>
         </Box>
-        <VStack pt="20px" w={{ lg: '35%', md: '45%', sm: '70%' }}>
-          <Text fontSize={'2xl'}>ひとことメモ</Text>
-          <Text fontSize={'xl'}>{aquariumDetail.description ?? '調査中です！しばらくお待ちください。'}</Text>
-        </VStack>
-      </VStack>
-      <VStack py="25px" spacing={0}>
-        <Text fontSize="3xl">この水族館で観られるウツボ</Text>
-        <Text color="red.500" fontSize="md">
-          ※ご注意※
-        </Text>
-        <Text color="red.500" fontSize="md">
-          展示されるウツボは通知無く変更される場合があります。
-        </Text>
-      </VStack>
-      <Wrap justify="center" pb={8} spacing={8}>
-        {aquariumDetail.morays.map((moray) => (
-          <WrapItem key={moray.id} mx="auto">
-            <LinkBox
-              _hover={{ cursor: 'pointer', opacity: 0.8 }}
-              bg="whiteAlpha.800"
-              borderRadius="30px"
-              h="300px"
-              p={4}
-              shadow="lg"
-              w="230px"
-            >
-              <Stack spacing={1} textAlign="center">
-                <Image
-                  alt="moray_image"
-                  borderRadius="full"
-                  boxSize="160px"
-                  m="auto"
-                  src={`/moray_image/${moray.avatar}`}
-                />
-                <LinkOverlay as={NextLink} fontSize="xl" fontWeight="bold" href={`/morays/${moray.id}`}>
-                  {moray.name_ja}
-                </LinkOverlay>
-                <Text>{moray.name_en}</Text>
-                <Text>最大長: {moray.max_length_str}</Text>
-              </Stack>
-            </LinkBox>
-          </WrapItem>
-        ))}
-      </Wrap>
+      </Center>
+      <Box m="auto" pb={8} w="90%">
+        <Grid gap={8} justifyContent="center" templateColumns="repeat(auto-fit, 230px)">
+          {aquariumDetail.morays.map((moray) => (
+            <GridItem key={moray.id}>
+              <LinkBox
+                _hover={{ cursor: 'pointer', opacity: 0.8 }}
+                bg="whiteAlpha.800"
+                borderRadius="30px"
+                h="300px"
+                p={4}
+                shadow="lg"
+                w="230px"
+              >
+                <Stack spacing={1} textAlign="center">
+                  <Image
+                    alt="moray_image"
+                    borderRadius="full"
+                    boxSize="160px"
+                    m="auto"
+                    src={`/moray_image/${moray.avatar}`}
+                  />
+                  <LinkOverlay as={NextLink} fontSize="xl" fontWeight="bold" href={`/morays/${moray.id}`}>
+                    {moray.name_ja}
+                  </LinkOverlay>
+                  <Text>{moray.name_en}</Text>
+                  <Text>最大長: {moray.max_length_str}</Text>
+                </Stack>
+              </LinkBox>
+            </GridItem>
+          ))}
+        </Grid>
+      </Box>
       <VStack py="25px">
         <Text fontSize="2xl">コメント</Text>
       </VStack>

--- a/src/pages/aquaria/index.tsx
+++ b/src/pages/aquaria/index.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 
-import { Center, Image, LinkBox, LinkOverlay, Stack, Text, Wrap, WrapItem } from '@chakra-ui/react';
+import { Box, Center, Grid, GridItem, Image, LinkBox, LinkOverlay, Stack, Text } from '@chakra-ui/react';
 import axios from 'axios';
 import Head from 'next/head';
 import NextLink from 'next/link';
@@ -20,28 +20,6 @@ export default function Aquaria() {
     axios.get(`${process.env.NEXT_PUBLIC_BASE_URL}/aquaria`).then((res) => setAquaria(res.data));
   }, []);
 
-  const aquaria_hokkaido = aquaria.filter((aquarium) => aquarium.region === '北海道');
-  const aquaria_tohoku = aquaria.filter((aquarium) => aquarium.region === '東北');
-  const aquaria_kanto = aquaria.filter((aquarium) => aquarium.region === '関東');
-  const aquaria_chubu = aquaria.filter((aquarium) => aquarium.region === '中部');
-  const aquaria_kinki = aquaria.filter((aquarium) => aquarium.region === '近畿');
-  const aquaria_chugoku = aquaria.filter((aquarium) => aquarium.region === '中国');
-  const aquaria_shikoku = aquaria.filter((aquarium) => aquarium.region === '四国');
-  const aquaria_kyushu = aquaria.filter((aquarium) => aquarium.region === '九州');
-  const aquaria_okinawa = aquaria.filter((aquarium) => aquarium.region === '沖縄');
-
-  const aquaria_all_region = [
-    { data: aquaria_hokkaido, region: '北海道' },
-    { data: aquaria_tohoku, region: '東北' },
-    { data: aquaria_kanto, region: '関東' },
-    { data: aquaria_chubu, region: '中部' },
-    { data: aquaria_kinki, region: '近畿' },
-    { data: aquaria_chugoku, region: '中国' },
-    { data: aquaria_shikoku, region: '四国' },
-    { data: aquaria_kyushu, region: '九州' },
-    { data: aquaria_okinawa, region: '沖縄' },
-  ];
-
   return (
     <>
       <Head>
@@ -50,42 +28,37 @@ export default function Aquaria() {
       <Center py="25px">
         <Text fontSize="3xl">水族館一覧</Text>
       </Center>
-      {aquaria_all_region.map((aquaria_region) => (
-        <>
-          <Center key={aquaria_region.region} py="25px">
-            <Text fontSize="2xl">{aquaria_region.region}</Text>
-          </Center>
-          <Wrap justify="center" pb={8} spacing={8}>
-            {aquaria_region.data.map((aquarium) => (
-              <WrapItem key={aquarium.id} mx="auto">
-                <LinkBox
-                  _hover={{ cursor: 'pointer', opacity: 0.8 }}
-                  bg="whiteAlpha.800"
-                  borderRadius="30px"
-                  h="250px"
-                  rounded="lg"
-                  shadow="lg"
-                  w="300px"
-                >
-                  <Stack spacing={1} textAlign="center">
-                    <Image
-                      alt={aquarium.name}
-                      m="auto"
-                      pb="8px"
-                      roundedTop="lg"
-                      src={`/aquarium_image/${aquarium.image}`}
-                    />
-                    <LinkOverlay as={NextLink} fontSize="lg" fontWeight="bold" href={`/aquaria/${aquarium.id}`}>
-                      {aquarium.name}
-                    </LinkOverlay>
-                    <Text>{aquarium.address_city}</Text>
-                  </Stack>
-                </LinkBox>
-              </WrapItem>
-            ))}
-          </Wrap>
-        </>
-      ))}
+      <Box m="auto" pb={8} w="90%">
+        <Grid gap={8} justifyContent="center" templateColumns="repeat(auto-fit, 300px)">
+          {aquaria.map((aquarium) => (
+            <GridItem key={aquarium.id}>
+              <LinkBox
+                _hover={{ cursor: 'pointer', opacity: 0.8 }}
+                bg="whiteAlpha.800"
+                borderRadius="30px"
+                h="250px"
+                rounded="lg"
+                shadow="lg"
+                w="300px"
+              >
+                <Stack spacing={1} textAlign="center">
+                  <Image
+                    alt={aquarium.name}
+                    m="auto"
+                    pb="8px"
+                    roundedTop="lg"
+                    src={`/aquarium_image/${aquarium.image}`}
+                  />
+                  <LinkOverlay as={NextLink} fontSize="lg" fontWeight="bold" href={`/aquaria/${aquarium.id}`}>
+                    {aquarium.name}
+                  </LinkOverlay>
+                  <Text>{aquarium.address_city}</Text>
+                </Stack>
+              </LinkBox>
+            </GridItem>
+          ))}
+        </Grid>
+      </Box>
     </>
   );
 }

--- a/src/pages/morays/[id].tsx
+++ b/src/pages/morays/[id].tsx
@@ -18,9 +18,9 @@ import {
   Text,
   Textarea,
   VStack,
-  Wrap,
-  WrapItem,
   Icon,
+  Grid,
+  GridItem,
 } from '@chakra-ui/react';
 import axios from 'axios';
 import { parseISO } from 'date-fns';
@@ -157,57 +157,63 @@ export default function MorayDetail() {
       <Center py="25px">
         <Text fontSize="3xl">{morayDetail.name_ja}</Text>
       </Center>
-      <VStack>
-        <Image alt="moray_image" borderRadius="full" boxSize="200px" src={`/moray_image/${morayDetail.avatar}`} />
-        <Box pt="25px">
-          <Text fontSize={'xl'}>{`英名　: ${morayDetail.name_en ?? '???'}`}</Text>
-          <Text fontSize={'xl'}>{`学名　: ${morayDetail.name_academic ?? '???'}`}</Text>
-          {/* <Text fontSize={'xl'}>分布: {morayDetail.distribution}</Text> */}
-          <Text fontSize={'xl'}>{`最大長: ${morayDetail.max_length_str ?? '???cm'}`}</Text>
+      <Center>
+        <Box w={{ base: '85%', lg: '100%', md: '85%' }}>
+          <VStack>
+            <Image alt="moray_image" borderRadius="full" boxSize="200px" src={`/moray_image/${morayDetail.avatar}`} />
+            <Box pt="25px">
+              <Text fontSize={'xl'}>{`英名　: ${morayDetail.name_en ?? '???'}`}</Text>
+              <Text fontSize={'xl'}>{`学名　: ${morayDetail.name_academic ?? '???'}`}</Text>
+              {/* <Text fontSize={'xl'}>分布: {morayDetail.distribution}</Text> */}
+              <Text fontSize={'xl'}>{`最大長: ${morayDetail.max_length_str ?? '???cm'}`}</Text>
+            </Box>
+            <VStack pt="20px" w={{ base: '70%', lg: '35%', md: '45%' }}>
+              <Text fontSize={'2xl'}>ひとことメモ</Text>
+              <Text fontSize={'xl'}>{morayDetail.description ?? '調査中です！しばらくお待ちください。'}</Text>
+            </VStack>
+          </VStack>
+          <VStack py="25px" spacing={0}>
+            <Text fontSize="2xl">このウツボが観られる水族館</Text>
+            <Text color="red.500" fontSize="sm">
+              ※ご注意※
+            </Text>
+            <Text color="red.500" fontSize="sm">
+              展示されるウツボは通知無く変更される場合があります。
+            </Text>
+          </VStack>
         </Box>
-        <VStack pt="20px" w={{ base: '70%', lg: '35%', md: '45%' }}>
-          <Text fontSize={'2xl'}>ひとことメモ</Text>
-          <Text fontSize={'xl'}>{morayDetail.description ?? '調査中です！しばらくお待ちください。'}</Text>
-        </VStack>
-      </VStack>
-      <VStack py="25px" spacing={0}>
-        <Text fontSize="2xl">このウツボが観られる水族館</Text>
-        <Text color="red.500" fontSize="sm">
-          ※ご注意※
-        </Text>
-        <Text color="red.500" fontSize="sm">
-          展示されるウツボは通知無く変更される場合があります。
-        </Text>
-      </VStack>
-      <Wrap justify="center" pb={8} spacing={8}>
-        {morayDetail.aquaria.map((aquarium) => (
-          <WrapItem key={aquarium.id} mx="auto">
-            <LinkBox
-              _hover={{ cursor: 'pointer', opacity: 0.8 }}
-              bg="whiteAlpha.800"
-              borderRadius="30px"
-              h="250px"
-              rounded="lg"
-              shadow="lg"
-              w="300px"
-            >
-              <Stack spacing={1} textAlign="center">
-                <Image
-                  alt={aquarium.name}
-                  m="auto"
-                  pb="8px"
-                  roundedTop="lg"
-                  src={`/aquarium_image/${aquarium.image}`}
-                />
-                <LinkOverlay as={NextLink} fontSize="lg" fontWeight="bold" href={`/aquaria/${aquarium.id}`}>
-                  {aquarium.name}
-                </LinkOverlay>
-                <Text>{aquarium.address_city}</Text>
-              </Stack>
-            </LinkBox>
-          </WrapItem>
-        ))}
-      </Wrap>
+      </Center>
+      <Box m="auto" pb={8} w="90%">
+        <Grid gap={8} justifyContent="center" templateColumns="repeat(auto-fit, 300px)">
+          {morayDetail.aquaria.map((aquarium) => (
+            <GridItem key={aquarium.id}>
+              <LinkBox
+                _hover={{ cursor: 'pointer', opacity: 0.8 }}
+                bg="whiteAlpha.800"
+                borderRadius="30px"
+                h="250px"
+                rounded="lg"
+                shadow="lg"
+                w="300px"
+              >
+                <Stack spacing={1} textAlign="center">
+                  <Image
+                    alt={aquarium.name}
+                    m="auto"
+                    pb="8px"
+                    roundedTop="lg"
+                    src={`/aquarium_image/${aquarium.image}`}
+                  />
+                  <LinkOverlay as={NextLink} fontSize="lg" fontWeight="bold" href={`/aquaria/${aquarium.id}`}>
+                    {aquarium.name}
+                  </LinkOverlay>
+                  <Text>{aquarium.address_city}</Text>
+                </Stack>
+              </LinkBox>
+            </GridItem>
+          ))}
+        </Grid>
+      </Box>
       <VStack py="25px">
         <Text fontSize="2xl">コメント</Text>
       </VStack>

--- a/src/pages/morays/[id].tsx
+++ b/src/pages/morays/[id].tsx
@@ -162,10 +162,10 @@ export default function MorayDetail() {
           <VStack>
             <Image alt="moray_image" borderRadius="full" boxSize="200px" src={`/moray_image/${morayDetail.avatar}`} />
             <Box pt="25px">
-              <Text fontSize={'xl'}>{`英名　: ${morayDetail.name_en ?? '???'}`}</Text>
-              <Text fontSize={'xl'}>{`学名　: ${morayDetail.name_academic ?? '???'}`}</Text>
+              <Text fontSize={'xl'}>{`英名　: ${morayDetail.name_en ?? '?'}`}</Text>
+              <Text fontSize={'xl'}>{`学名　: ${morayDetail.name_academic ?? '?'}`}</Text>
               {/* <Text fontSize={'xl'}>分布: {morayDetail.distribution}</Text> */}
-              <Text fontSize={'xl'}>{`最大長: ${morayDetail.max_length_str ?? '???cm'}`}</Text>
+              <Text fontSize={'xl'}>{`最大長: ${morayDetail.max_length_str ?? '? cm'}`}</Text>
             </Box>
             <VStack pt="20px" w={{ base: '70%', lg: '35%', md: '45%' }}>
               <Text fontSize={'2xl'}>ひとことメモ</Text>

--- a/src/pages/morays/index.tsx
+++ b/src/pages/morays/index.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 
-import { Center, Image, LinkBox, LinkOverlay, Stack, Text, Wrap, WrapItem } from '@chakra-ui/react';
+import { Box, Center, Grid, GridItem, Image, LinkBox, LinkOverlay, Stack, Text } from '@chakra-ui/react';
 import axios from 'axios';
 import Head from 'next/head';
 import NextLink from 'next/link';
@@ -29,36 +29,38 @@ export default function Morays() {
       <Center py="25px">
         <Text fontSize="3xl">ウツボ一覧</Text>
       </Center>
-      <Wrap justify="center" pb={8} spacing={8}>
-        {morays.map((moray) => (
-          <WrapItem key={moray.id} mx="auto">
-            <LinkBox
-              _hover={{ cursor: 'pointer', opacity: 0.8 }}
-              bg="whiteAlpha.800"
-              borderRadius="30px"
-              h="300px"
-              p={4}
-              shadow="lg"
-              w="230px"
-            >
-              <Stack spacing={1} textAlign="center">
-                <Image
-                  alt="moray_image"
-                  borderRadius="full"
-                  boxSize="160px"
-                  m="auto"
-                  src={`/moray_image/${moray.avatar}`}
-                />
-                <LinkOverlay as={NextLink} fontSize="xl" fontWeight="bold" href={`/morays/${moray.id}`}>
-                  {moray.name_ja}
-                </LinkOverlay>
-                <Text>{moray.name_en}</Text>
-                <Text>最大長: {moray.max_length_str}</Text>
-              </Stack>
-            </LinkBox>
-          </WrapItem>
-        ))}
-      </Wrap>
+      <Box m="auto" pb={8} w="90%">
+        <Grid gap={8} justifyContent="center" templateColumns="repeat(auto-fit, 230px)">
+          {morays.map((moray) => (
+            <GridItem key={moray.id}>
+              <LinkBox
+                _hover={{ cursor: 'pointer', opacity: 0.8 }}
+                bg="whiteAlpha.800"
+                borderRadius="30px"
+                h="300px"
+                p={4}
+                shadow="lg"
+                w="230px"
+              >
+                <Stack spacing={1} textAlign="center">
+                  <Image
+                    alt="moray_image"
+                    borderRadius="full"
+                    boxSize="160px"
+                    m="auto"
+                    src={`/moray_image/${moray.avatar}`}
+                  />
+                  <LinkOverlay as={NextLink} fontSize="xl" fontWeight="bold" href={`/morays/${moray.id}`}>
+                    {moray.name_ja}
+                  </LinkOverlay>
+                  <Text>{moray.name_en}</Text>
+                  <Text>最大長: {moray.max_length_str}</Text>
+                </Stack>
+              </LinkBox>
+            </GridItem>
+          ))}
+        </Grid>
+      </Box>
     </>
   );
 }

--- a/src/pages/morays/index.tsx
+++ b/src/pages/morays/index.tsx
@@ -53,8 +53,8 @@ export default function Morays() {
                   <LinkOverlay as={NextLink} fontSize="xl" fontWeight="bold" href={`/morays/${moray.id}`}>
                     {moray.name_ja}
                   </LinkOverlay>
-                  <Text>{moray.name_en}</Text>
-                  <Text>最大長: {moray.max_length_str}</Text>
+                  <Text>{moray.name_en ?? '?'}</Text>
+                  <Text>最大長: {moray.max_length_str ?? '? cm'}</Text>
                 </Stack>
               </LinkBox>
             </GridItem>

--- a/src/pages/privacy/index.tsx
+++ b/src/pages/privacy/index.tsx
@@ -12,7 +12,7 @@ export default function Privacy() {
         <Text fontSize="3xl">プライバシーポリシー</Text>
       </Center>
       <Center>
-        <Box w={{ lg: '55%', md: '70%', sm: '90%' }}>
+        <Box w={{ base: '85%', lg: '55%', md: '70%' }}>
           <Divider borderColor="black" />
           <Text py={8}>
             うつぼさいとの管理者（以下、「管理者といいます。」）は、本ウェブサイト上で提供するサービス（以下「本サービス」といいます。）における、ユーザーについての個人情報を含む利用者情報の取扱いについて、以下のとおりプライバシーポリシーを定めます。

--- a/src/pages/profile/edit.tsx
+++ b/src/pages/profile/edit.tsx
@@ -110,60 +110,58 @@ export default function ProfileEdit() {
       <Center>
         {/* <form onSubmit={handleSubmit(onSubmit)}> */}
         <form onSubmit={onSubmit}>
-          <Box w="lg">
-            <FormControl>
-              <FormLabel fontSize={'xl'}>アイコン画像</FormLabel>
-              <HStack pt={3}>
-                {profile?.avatar ? (
-                  <Avatar size={'xl'} src={currentUser?.photoURL ?? undefined} />
-                ) : (
-                  <Avatar size={'xl'} src="/default-user-icon.png" />
-                )}
-                {!currentUser?.isAnonymous && !loading && (
-                  <RadioGroup
-                    defaultValue={userInfo.avatar ? 'google-icon' : 'default'}
-                    onChange={(value) => handleChangeAvatar(value)}
-                    px={10}
-                  >
-                    <Box>
-                      <Radio bg="whiteAlpha.900" value="default">
-                        デフォルト画像を使用する
-                      </Radio>
-                      <Radio bg="whiteAlpha.900" value="google-icon">
-                        Googleアイコンを使用する
-                      </Radio>
-                    </Box>
-                  </RadioGroup>
-                )}
-              </HStack>
-            </FormControl>
-            {/* <FormControl id="name" isInvalid={!!errors.profile?.name}> */}
-            <FormControl id="name">
-              <FormLabel fontSize={'xl'} htmlFor="name" mt={5}>
-                ユーザー名
-              </FormLabel>
-              <Input
-                bg="whiteAlpha.900"
-                // error={errors.profile?.name}
-                id="name"
-                onChange={(e) => setProfile({ ...profile, name: e.target.value })}
-                type="text"
-                value={profile.name}
-                // {...register('profile.name')}
-              />
-              {/* <FormErrorMessage>{errors.profile?.name.message && errors.profile?.name.message}</FormErrorMessage> */}
-            </FormControl>
-            <Center mt={8}>
-              <HStack spacing={100}>
-                <Button bg="whiteAlpha.900" onClick={onCancel} w="100px">
-                  キャンセル
-                </Button>
-                <Button bg="blue.500" color="whiteAlpha.900" type="submit" w="100px">
-                  更新する
-                </Button>
-              </HStack>
-            </Center>
-          </Box>
+          <FormControl>
+            <FormLabel fontSize={'xl'}>アイコン画像</FormLabel>
+            <HStack pt={3}>
+              {profile?.avatar ? (
+                <Avatar size={'xl'} src={currentUser?.photoURL ?? undefined} />
+              ) : (
+                <Avatar size={'xl'} src="/default-user-icon.png" />
+              )}
+              {!currentUser?.isAnonymous && !loading && (
+                <RadioGroup
+                  defaultValue={userInfo.avatar ? 'google-icon' : 'default'}
+                  onChange={(value) => handleChangeAvatar(value)}
+                  px={{ base: 6, sm: 10 }}
+                >
+                  <Box display="flex" flexDir="column" justifyContent="flex-start">
+                    <Radio bg="whiteAlpha.900" value="default">
+                      <Text fontSize={{ base: 'sm', lg: 'md', md: 'md', sm: 'md' }}>デフォルト画像を使用する</Text>
+                    </Radio>
+                    <Radio bg="whiteAlpha.900" value="google-icon">
+                      <Text fontSize={{ base: 'sm', lg: 'md', md: 'md', sm: 'md' }}>Googleアイコンを使用する</Text>
+                    </Radio>
+                  </Box>
+                </RadioGroup>
+              )}
+            </HStack>
+          </FormControl>
+          {/* <FormControl id="name" isInvalid={!!errors.profile?.name}> */}
+          <FormControl id="name">
+            <FormLabel fontSize={'xl'} htmlFor="name" mt={5}>
+              ユーザー名
+            </FormLabel>
+            <Input
+              bg="whiteAlpha.900"
+              // error={errors.profile?.name}
+              id="name"
+              onChange={(e) => setProfile({ ...profile, name: e.target.value })}
+              type="text"
+              value={profile.name}
+              // {...register('profile.name')}
+            />
+            {/* <FormErrorMessage>{errors.profile?.name.message && errors.profile?.name.message}</FormErrorMessage> */}
+          </FormControl>
+          <Center mt={8}>
+            <HStack spacing={100}>
+              <Button bg="whiteAlpha.900" onClick={onCancel} w="100px">
+                キャンセル
+              </Button>
+              <Button _hover={{ bg: 'blue.300' }} bg="blue.500" color="whiteAlpha.900" type="submit" w="100px">
+                更新する
+              </Button>
+            </HStack>
+          </Center>
         </form>
       </Center>
     </>

--- a/src/pages/signin/index.tsx
+++ b/src/pages/signin/index.tsx
@@ -1,5 +1,5 @@
 import { InfoOutlineIcon } from '@chakra-ui/icons';
-import { Box, Button, Center, Divider, HStack, Stack, Text, Tooltip, VStack } from '@chakra-ui/react';
+import { Box, Button, Center, Divider, HStack, Text, Tooltip, VStack } from '@chakra-ui/react';
 import axios from 'axios';
 import Head from 'next/head';
 import { FcGoogle } from 'react-icons/fc';
@@ -38,45 +38,46 @@ export default function SigninPage() {
       <Center pt="25px">
         <Text fontSize="3xl">ログイン/ユーザー登録</Text>
       </Center>
-      <Box alignItems="center" display="flex" justifyContent="center" minH="calc(100vh - 64px - 70px - 61px)">
+      <Box alignItems="center" display="flex" justifyContent="center" minH="calc(100vh - 64px - 70px - 70px - 61px)">
         <Box
+          alignItems="center"
           bg="whiteAlpha.900"
-          borderRadius={{ base: 'none', sm: 'xl' }}
-          boxShadow={{ base: 'none', sm: 'md' }}
-          px={20}
-          py={10}
+          borderRadius="xl"
+          boxShadow="md"
+          display="flex"
+          h="280px"
+          justifyContent="center"
+          w={{ base: '85%', lg: '30%', md: '50%' }}
         >
-          <Stack spacing="8">
-            <VStack>
-              <Button maxW={'md'} onClick={() => handleLogin('guest')} variant={'outline'} w={'full'}>
-                ゲストログイン
-              </Button>
-              <Tooltip
-                aria-label="ゲストログインとは"
-                bg="white"
-                borderRadius="md"
-                color="blue.500"
-                h="120px"
-                label={
-                  <VStack alignItems="center" display="flex" justifyContent="center">
-                    <Text fontSize={'md'}>仮アカウントを作成し、ユーザー登録なしでログインできます。</Text>
-                    <Text fontSize={'md'}>ログアウト後に同じアカウントでの再ログインはできません。</Text>
-                  </VStack>
-                }
-                w="400px"
-              >
-                <HStack textDecoration="underline">
-                  <InfoOutlineIcon />
-                  <Text fontSize={'sm'}>ゲストログインとは？</Text>
-                </HStack>
-              </Tooltip>
-            </VStack>
-            <HStack>
-              <Divider />
-              <Text color="muted" fontSize="sm" whiteSpace="nowrap">
+          <VStack>
+            <Button maxW={'md'} onClick={() => handleLogin('guest')} variant={'outline'} w={'full'}>
+              ゲストログイン
+            </Button>
+            <Tooltip
+              aria-label="ゲストログインとは"
+              bg="white"
+              borderRadius="md"
+              color="blue.500"
+              h="120px"
+              label={
+                <VStack alignItems="center" display="flex" justifyContent="center">
+                  <Text fontSize={'md'}>仮アカウントを作成し、ユーザー登録なしでログインできます。</Text>
+                  <Text fontSize={'md'}>ログアウト後に同じアカウントでの再ログインはできません。</Text>
+                </VStack>
+              }
+              w="400px"
+            >
+              <HStack textDecoration="underline">
+                <InfoOutlineIcon />
+                <Text fontSize={'sm'}>ゲストログインとは？</Text>
+              </HStack>
+            </Tooltip>
+            <HStack py={6}>
+              <Divider borderColor="gray.300" w={28} />
+              <Text fontSize="sm" whiteSpace="nowrap">
                 または
               </Text>
-              <Divider />
+              <Divider borderColor="gray.400" w={28} />
             </HStack>
             <Button
               leftIcon={<FcGoogle />}
@@ -89,7 +90,7 @@ export default function SigninPage() {
                 <Text>Googleでログイン / ユーザー登録</Text>
               </Center>
             </Button>
-          </Stack>
+          </VStack>
         </Box>
       </Box>
     </>

--- a/src/pages/terms/index.tsx
+++ b/src/pages/terms/index.tsx
@@ -11,7 +11,7 @@ export default function Terms() {
         <Text fontSize="3xl">利用規約</Text>
       </Center>
       <Center>
-        <Box w={{ lg: '55%', md: '70%', sm: '90%' }}>
+        <Box w={{ base: '85%', lg: '55%', md: '70%' }}>
           <Divider borderColor="black" />
           <Text py={8}>
             本利用規約（以下「本規約」といいます。）には、本サービスの提供条件及び本サイトの管理者（以下「管理者」といいます。）と登録ユーザーの皆様との間の権利義務関係が定められています。本サービスの利用に際しては、本規約の全文をお読みいただいたうえで、本規約に同意いただく必要があります。


### PR DESCRIPTION
## 対象Issue

[スタイルの修正 #46](https://github.com/Utsubo256/utsubo-site-client/issues/46)

## 実施内容

- Issueに記載したスタイルが崩れている箇所の修正

## 動作確認

- メニューバーのリンクをクリックした後、メニューバーが自動で閉じることを確認
- 現状、地域別に表示している水族館一覧を、ウツボ一覧のように横並びに表示されていることを確認
- スマホサイズの際、画面横ギリギリまで表示されているのが修正されていることを確認
- スマホサイズで\フッターのスタイルが崩れているので崩れていないことを確認

close #46 