### PR TITLE
ウツボ詳細/水族館詳細ページにウツボ動画を追加

### DIFF
--- a/src/pages/aquaria/[id].tsx
+++ b/src/pages/aquaria/[id].tsx
@@ -93,6 +93,7 @@ export default function AquariumDetail() {
     name: '',
     region: '',
     site_url: '',
+    video_url: '',
   });
 
   const [aquariumCommentInput, setAquariumCommentInput] = useState<AquariumCommentInput>({

--- a/src/pages/aquaria/[id].tsx
+++ b/src/pages/aquaria/[id].tsx
@@ -57,6 +57,7 @@ type Aquarium = {
   name: string;
   region: string;
   site_url: string;
+  video_url: string;
 };
 
 type AquariumComments = {

--- a/src/pages/aquaria/[id].tsx
+++ b/src/pages/aquaria/[id].tsx
@@ -1,11 +1,13 @@
 import { useEffect, useState } from 'react';
 
 import {
+  AspectRatio,
   Avatar,
   Box,
   Button,
   Center,
   Divider,
+  Flex,
   Grid,
   GridItem,
   HStack,
@@ -196,6 +198,20 @@ export default function AquariumDetail() {
               <Text fontSize={'xl'}>{aquariumDetail.description ?? '調査中です！しばらくお待ちください。'}</Text>
             </VStack>
           </VStack>
+          {aquariumDetail.video_url ? (
+            <>
+              <VStack>
+                <VStack pt="20px" w={{ base: '70%', lg: '35%', md: '45%' }}>
+                  <Text fontSize={'2xl'}>ウツボ動画</Text>
+                </VStack>
+              </VStack>
+              <Flex justifyContent="center">
+                <AspectRatio ratio={16 / 9} w={{ base: '100%', lg: '50%', md: '80%' }}>
+                  <iframe allowFullScreen src={`https://www.youtube-nocookie.com/embed/${aquariumDetail.video_url}`} />
+                </AspectRatio>
+              </Flex>
+            </>
+          ) : null}
           <VStack py="25px" spacing={0}>
             <Text fontSize="2xl">この水族館で観られるウツボ</Text>
             <Text color="red.500" fontSize="sm">

--- a/src/pages/morays/[id].tsx
+++ b/src/pages/morays/[id].tsx
@@ -21,6 +21,8 @@ import {
   Icon,
   Grid,
   GridItem,
+  Flex,
+  AspectRatio,
 } from '@chakra-ui/react';
 import axios from 'axios';
 import { parseISO } from 'date-fns';
@@ -172,6 +174,20 @@ export default function MorayDetail() {
               <Text fontSize={'xl'}>{morayDetail.description ?? '調査中です！しばらくお待ちください。'}</Text>
             </VStack>
           </VStack>
+          {morayDetail.video_url ? (
+            <>
+              <VStack>
+                <VStack pt="20px" w={{ base: '70%', lg: '35%', md: '45%' }}>
+                  <Text fontSize={'2xl'}>ウツボ動画</Text>
+                </VStack>
+              </VStack>
+              <Flex justifyContent="center">
+                <AspectRatio ratio={16 / 9} w={{ base: '100%', lg: '50%', md: '80%' }}>
+                  <iframe allowFullScreen src={`https://www.youtube-nocookie.com/embed/${morayDetail.video_url}`} />
+                </AspectRatio>
+              </Flex>
+            </>
+          ) : null}
           <VStack py="25px" spacing={0}>
             <Text fontSize="2xl">このウツボが観られる水族館</Text>
             <Text color="red.500" fontSize="sm">


### PR DESCRIPTION
## 対象Issue

[ウツボ詳細/水族館詳細ページにウツボ動画を追加 #48](https://github.com/Utsubo256/utsubo-site-client/issues/48)

## 実施内容

- ウツボ詳細/水族館詳細ページにウツボ動画を追加する

## 動作確認

- DBのvideo_url (動画url)に文字列が設定されている場合は動画が表示されていることを確認

close #48 