### PR TITLE
ログイン/ログアウト後にすぐに3dot menuの状態が期待通りになるよう修正

### DIFF
--- a/src/components/Layout/Header.tsx
+++ b/src/components/Layout/Header.tsx
@@ -93,7 +93,7 @@ export default function Header() {
                       プロフィール編集
                     </MenuItem>
                     <MenuDivider />
-                    <MenuItem icon={<BiLogOut />} onClick={() => logout()}>
+                    <MenuItem icon={<BiLogOut />} onClick={logout}>
                       ログアウト
                     </MenuItem>
                   </MenuList>

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -8,8 +8,8 @@ import type { User } from 'firebase/auth';
 
 type UserInfo = {
   avatar: string | null;
-  id: number;
   name: string;
+  uid: string;
 };
 
 type AuthContextType = {
@@ -33,8 +33,8 @@ export function AuthContextProvider({ children }: Props) {
   const { currentUser, loading, loginWithFirebase, logout } = useFirebaseAuth();
   const [userInfo, setUserInfo] = useState({
     avatar: cookies.avatar,
-    id: Number(cookies.id),
     name: cookies.name,
+    uid: cookies.uid,
   });
 
   const updateUserInfo = (newUserInfo: UserInfo) => {

--- a/src/lib/manageCookies.ts
+++ b/src/lib/manageCookies.ts
@@ -2,12 +2,12 @@ import nookies, { setCookie, destroyCookie } from 'nookies';
 
 type UserInfo = {
   avatar: string | null;
-  id: number;
   name: string;
+  uid: string;
 };
 
 export const setUserInfoCookies = (userInfo: UserInfo) => {
-  setCookie(null, 'id', String(userInfo.id), {
+  setCookie(null, 'uid', userInfo.uid, {
     maxAge: 30 * 24 * 60 * 60,
     path: '/',
   });
@@ -25,4 +25,5 @@ export const clearUserInfoCookies = () => {
   nookies.destroy(null, 'token');
   destroyCookie(null, 'name');
   destroyCookie(null, 'avatar');
+  destroyCookie(null, 'uid');
 };

--- a/src/pages/aquaria/[id].tsx
+++ b/src/pages/aquaria/[id].tsx
@@ -67,8 +67,8 @@ type AquariumComments = {
   image: string | null;
   user: {
     avatar: string | null;
-    id: number;
     name: string;
+    uid: string;
   };
 };
 

--- a/src/pages/aquaria/[id].tsx
+++ b/src/pages/aquaria/[id].tsx
@@ -101,6 +101,8 @@ export default function AquariumDetail() {
   });
   const [aquariumComments, setAquariumComments] = useState<AquariumComments[]>([]);
 
+  const [isAuthor, setIsAuthor] = useState(false);
+
   function onSubmit(e: React.SyntheticEvent) {
     e.preventDefault();
     const data = {
@@ -151,6 +153,12 @@ export default function AquariumDetail() {
         .then((res) => setAquariumComments(res.data));
     }
   }, [id, router]);
+
+  useEffect(() => {
+    if (!loading && currentUser && currentUser.uid === userInfo.uid) {
+      setIsAuthor(true);
+    }
+  }, [currentUser, loading, userInfo.uid]);
 
   function elapsedTimeFromNow(datetime: string) {
     return formatDistanceToNow(parseISO(datetime), { locale: ja });
@@ -341,7 +349,7 @@ export default function AquariumDetail() {
                       <Text fontSize="xs">{elapsedTimeFromNow(aquariumComment.created_at)}</Text>
                     </HStack>
                     <Menu>
-                      {aquariumComment.user.id === Number(userInfo.id) ? (
+                      {isAuthor && aquariumComment.user.uid === userInfo.uid && (
                         <Box>
                           <MenuButton>
                             <Icon as={BsThreeDots} boxSize="20px" />
@@ -351,7 +359,7 @@ export default function AquariumDetail() {
                             <MenuItem onClick={() => onDelete(aquariumComment.id)}>削除する</MenuItem>
                           </MenuList>
                         </Box>
-                      ) : null}
+                      )}
                     </Menu>
                   </Box>
                 </Box>

--- a/src/pages/morays/[id].tsx
+++ b/src/pages/morays/[id].tsx
@@ -64,8 +64,9 @@ type MorayComments = {
   image: string | null;
   user: {
     avatar: string | null;
-    id: number;
     name: string;
+    uid: string;
+    uid: string;
   };
 };
 
@@ -96,6 +97,8 @@ export default function MorayDetail() {
     body: '',
   });
   const [morayComments, setMorayComments] = useState<MorayComments[]>([]);
+
+  const [isAuthor, setIsAuthor] = useState(false);
 
   function onSubmit(e: React.SyntheticEvent) {
     e.preventDefault();
@@ -146,6 +149,12 @@ export default function MorayDetail() {
         .then((res) => setMorayComments(res.data));
     }
   }, [id, router]);
+
+  useEffect(() => {
+    if (!loading && currentUser && currentUser.uid === userInfo.uid) {
+      setIsAuthor(true);
+    }
+  }, [currentUser, loading, userInfo.uid]);
 
   function elapsedTimeFromNow(datetime: string) {
     return formatDistanceToNow(parseISO(datetime), { locale: ja });
@@ -314,7 +323,7 @@ export default function MorayDetail() {
                       <Text fontSize="xs">{elapsedTimeFromNow(morayComment.created_at)}</Text>
                     </HStack>
                     <Menu>
-                      {morayComment.user.id === Number(userInfo.id) ? (
+                      {isAuthor && morayComment.user.uid === userInfo.uid && (
                         <Box>
                           <MenuButton>
                             <Icon as={BsThreeDots} boxSize="20px" />
@@ -324,7 +333,7 @@ export default function MorayDetail() {
                             <MenuItem onClick={() => onDelete(morayComment.id)}>削除する</MenuItem>
                           </MenuList>
                         </Box>
-                      ) : null}
+                      )}
                     </Menu>
                   </Box>
                 </Box>

--- a/src/pages/morays/[id].tsx
+++ b/src/pages/morays/[id].tsx
@@ -66,7 +66,6 @@ type MorayComments = {
     avatar: string | null;
     name: string;
     uid: string;
-    uid: string;
   };
 };
 

--- a/src/pages/profile/index.tsx
+++ b/src/pages/profile/index.tsx
@@ -10,8 +10,8 @@ import { useAuthContext } from '@/context/AuthContext';
 
 type Profile = {
   avatar: string | null;
-  id: number;
   name: string;
+  uid: string;
 };
 
 export default function Profile() {

--- a/src/pages/profile/index.tsx
+++ b/src/pages/profile/index.tsx
@@ -18,8 +18,8 @@ export default function Profile() {
   const router = useRouter();
   const [profile, setProfile] = useState<Profile>({
     avatar: '',
-    id: 0,
     name: '',
+    uid: '',
   });
 
   const { currentUser, loading } = useAuthContext();

--- a/src/pages/signin/index.tsx
+++ b/src/pages/signin/index.tsx
@@ -9,8 +9,8 @@ import { setUserInfoCookies } from '@/lib/manageCookies';
 
 type UserInfo = {
   avatar: string | null;
-  id: number;
   name: string;
+  uid: string;
 };
 
 export default function SigninPage() {


### PR DESCRIPTION
## 対象Issue

[ウツボ詳細/水族館詳細ページのコメント欄のバグ修正 #51](https://github.com/Utsubo256/utsubo-site-client/issues/51)

## 実施内容

- Issueに記載したバグの修正

## 動作確認

- ログイン後、ウツボ詳細/水族館詳細ページのコメント欄に自分がコメントしたものに3dot menuが表示されていることを確認
- ログアウト後、3dot menuが表示されていないことを確認

close #51 